### PR TITLE
Avoid absolute paths in hooks

### DIFF
--- a/zfs-utils-git/zfs-utils.initcpio.hook
+++ b/zfs-utils-git/zfs-utils.initcpio.hook
@@ -2,8 +2,8 @@ ZPOOL_FORCE=""
 ZPOOL_IMPORT_FLAGS=""
 
 zfs_get_bootfs () {
-    for zfs_dataset in $(/usr/bin/zpool list -H -o bootfs); do
-        case ${zfs_dataset} in
+    for zfs_dataset in $(/usr/bin/zpool list -H -o bootfs) ; do
+        case $zfs_dataset in
             "" | "-")
                 # skip this line/dataset
                 ;;
@@ -11,7 +11,7 @@ zfs_get_bootfs () {
                 return 1
                 ;;
             *)
-                ZFS_DATASET=${zfs_dataset}
+                ZFS_DATASET=$zfs_dataset
                 return 0
                 ;;
         esac
@@ -20,7 +20,6 @@ zfs_get_bootfs () {
 }
 
 zfs_mount_handler () {
-    local node=$1
     if [ "$ZFS_DATASET" = "bootfs" ] ; then
         if ! zfs_get_bootfs ; then
             # Lets import everything and try again
@@ -35,44 +34,46 @@ zfs_mount_handler () {
     local pool="${ZFS_DATASET%%/*}"
     local rwopt_exp=${rwopt:-ro}
 
-    if ! "/usr/bin/zpool" list -H $pool 2>&1 > /dev/null ; then
-        if [ "$rwopt_exp" != "rw" ]; then
+    if ! "/usr/bin/zpool" list -H "$pool" 2>&1 > /dev/null ; then
+        if [ "$rwopt_exp" != "rw" ] ; then
             msg "ZFS: Importing pool $pool readonly."
             ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -o readonly=on"
         else
             msg "ZFS: Importing pool $pool."
         fi
 
-        if ! "/usr/bin/zpool" import $ZPOOL_IMPORT_FLAGS -N $pool $ZPOOL_FORCE ; then
+        if ! "/usr/bin/zpool" import $ZPOOL_IMPORT_FLAGS -N "$pool" $ZPOOL_FORCE ; then
             echo "ZFS: Unable to import pool $pool."
             return 1
         fi
     fi
 
-    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint $ZFS_DATASET)
+    local node=$1
+    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint "$ZFS_DATASET")
+
     if [ "$mountpoint" = "legacy" ] ; then
-        mount -t zfs -o ${rwopt_exp} "$ZFS_DATASET" "$node"
+        mount -t zfs -o "$rwopt_exp" "$ZFS_DATASET" "$node"
     else
-        mount -o zfsutil,${rwopt_exp} -t zfs "$ZFS_DATASET" "$node"
+        mount -t zfs -o "zfsutil,$rwopt_exp" "$ZFS_DATASET" "$node"
     fi
 }
 
-run_hook() {
+run_hook () {
     # Force import the pools, useful if the pool has not properly been exported
     # using 'zpool export <pool>'
-    [[ $zfs_force == 1 ]] && ZPOOL_FORCE='-f'
+    [[ $zfs_force == 1 ]] && ZPOOL_FORCE="-f"
     [[ "$zfs_import_dir" != "" ]] && ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -d $zfs_import_dir"
 
-    if [ "$root" = 'zfs' ]; then
-        mount_handler='zfs_mount_handler'
+    if [ "$root" = "zfs" ] ; then
+        mount_handler="zfs_mount_handler"
     fi
 
     case $zfs in
         "")
             # skip this line/dataset
             ;;
-        auto|bootfs)
-            ZFS_DATASET='bootfs'
+        "auto" | "bootfs")
+            ZFS_DATASET="bootfs"
             mount_handler="zfs_mount_handler"
             ;;
         *)
@@ -86,7 +87,7 @@ run_hook() {
     fi
 
     # Allow up to 10 seconds for zfs device to show up
-    for i in 1 2 3 4 5 6 7 8 9 10; do
+    for i in 1 2 3 4 5 6 7 8 9 10 ; do
         [ -c "/dev/zfs" ] && break
         sleep 1
     done

--- a/zfs-utils-git/zfs-utils.initcpio.hook
+++ b/zfs-utils-git/zfs-utils.initcpio.hook
@@ -2,7 +2,7 @@ ZPOOL_FORCE=""
 ZPOOL_IMPORT_FLAGS=""
 
 zfs_get_bootfs () {
-    for zfs_dataset in $(/usr/bin/zpool list -H -o bootfs) ; do
+    for zfs_dataset in $(zpool list -H -o bootfs) ; do
         case $zfs_dataset in
             "" | "-")
                 # skip this line/dataset
@@ -23,7 +23,7 @@ zfs_mount_handler () {
     if [ "$ZFS_DATASET" = "bootfs" ] ; then
         if ! zfs_get_bootfs ; then
             # Lets import everything and try again
-            /usr/bin/zpool import $ZPOOL_IMPORT_FLAGS -N -a $ZPOOL_FORCE
+            zpool import $ZPOOL_IMPORT_FLAGS -N -a $ZPOOL_FORCE
             if ! zfs_get_bootfs ; then
                 echo "ZFS: Cannot find bootfs."
                 return 1
@@ -34,7 +34,7 @@ zfs_mount_handler () {
     local pool="${ZFS_DATASET%%/*}"
     local rwopt_exp=${rwopt:-ro}
 
-    if ! "/usr/bin/zpool" list -H "$pool" 2>&1 > /dev/null ; then
+    if ! zpool list -H "$pool" 2>&1 > /dev/null ; then
         if [ "$rwopt_exp" != "rw" ] ; then
             msg "ZFS: Importing pool $pool readonly."
             ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -o readonly=on"
@@ -42,14 +42,14 @@ zfs_mount_handler () {
             msg "ZFS: Importing pool $pool."
         fi
 
-        if ! "/usr/bin/zpool" import $ZPOOL_IMPORT_FLAGS -N "$pool" $ZPOOL_FORCE ; then
+        if ! zpool import $ZPOOL_IMPORT_FLAGS -N "$pool" $ZPOOL_FORCE ; then
             echo "ZFS: Unable to import pool $pool."
             return 1
         fi
     fi
 
     local node=$1
-    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint "$ZFS_DATASET")
+    local mountpoint=$(zfs get -H -o value mountpoint "$ZFS_DATASET")
 
     if [ "$mountpoint" = "legacy" ] ; then
         mount -t zfs -o "$rwopt_exp" "$ZFS_DATASET" "$node"
@@ -95,7 +95,7 @@ run_hook () {
 
 
 run_latehook () {
-    /usr/bin/zpool import -N -a $ZPOOL_FORCE
+    zpool import -N -a $ZPOOL_FORCE
 }
 
 # vim:set ts=4 sw=4 ft=sh et:


### PR DESCRIPTION
This makes us more resilient against path changes. The shell is smart enough to resolve the path for us.