### PR TITLE
Support bootfs child datasets

### DIFF
--- a/zfs-utils-git/zfs-utils.initcpio.hook
+++ b/zfs-utils-git/zfs-utils.initcpio.hook
@@ -20,7 +20,6 @@ zfs_get_bootfs () {
 }
 
 zfs_mount_handler () {
-    local node=$1
     if [ "$ZFS_DATASET" = "bootfs" ] ; then
         if ! zfs_get_bootfs ; then
             # Lets import everything and try again
@@ -49,12 +48,21 @@ zfs_mount_handler () {
         fi
     fi
 
-    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint $ZFS_DATASET)
-    if [ "$mountpoint" = "legacy" ] ; then
-        mount -t zfs -o ${rwopt_exp} "$ZFS_DATASET" "$node"
-    else
-        mount -o zfsutil,${rwopt_exp} -t zfs "$ZFS_DATASET" "$node"
-    fi
+    local node=$1
+    local zfs_datasets=$(zfs list -H -o name -t filesystem -r "$ZFS_DATASET")
+
+    # Mount the root, and any non legacy child datasets
+    for dataset in $datasets; do
+        mountpoint=$(zfs get -H -o value mountpoint "$dataset")
+        case $mountpoint in
+            "none" | "legacy")
+                # skip this line/dataset.
+                ;;
+            *)
+                mount -t zfs -o "zfsutil,$rwopt_exp" "$dataset" "$node$mountpoint"
+                ;;
+        esac
+    done
 }
 
 run_hook() {

--- a/zfs-utils-git/zfs-utils.initcpio.hook
+++ b/zfs-utils-git/zfs-utils.initcpio.hook
@@ -49,14 +49,24 @@ zfs_mount_handler () {
     fi
 
     local node=$1
+    local tab_file="$node/etc/fstab"
     local zfs_datasets=$(zfs list -H -o name -t filesystem -r "$ZFS_DATASET")
 
-    # Mount the root, and any non legacy child datasets
-    for dataset in $datasets; do
+    # Mount the root, and any child datasets
+    for dataset in $zfs_datasets; do
         mountpoint=$(zfs get -H -o value mountpoint "$dataset")
         case $mountpoint in
-            "none" | "legacy")
+            "none")
                 # skip this line/dataset.
+                ;;
+            "legacy")
+                if [ -f "$tab_file" ]; then
+                    if findmnt -snero source -F "$tab_file" -S "$dataset" > /dev/null 2>&1; then
+                        opt=$(findmnt -snero options -F "$tab_file" -S "$dataset")
+                        mnt=$(findmnt -snero target -F "$tab_file" -S "$dataset")
+                        mount -t zfs -o "$opt" "$dataset" "$node$mnt"
+                    fi
+                fi
                 ;;
             *)
                 mount -t zfs -o "zfsutil,$rwopt_exp" "$dataset" "$node$mountpoint"

--- a/zfs-utils-git/zfs-utils.initcpio.install
+++ b/zfs-utils-git/zfs-utils.initcpio.install
@@ -29,7 +29,8 @@ build() {
         splat \
         hostid \
         /lib/udev/vdev_id \
-        /lib/udev/zvol_id
+        /lib/udev/zvol_id \
+        findmnt
 
     map add_file \
         /lib/udev/rules.d/60-zvol.rules \


### PR DESCRIPTION
Currently only the dataset defined by the `zfs` kernel parameter will get mounted during boot. For example (`zfs=bootfs`):

``` 
$ zfs list -o name,mountpoint
NAME               MOUNTPOINT
zroot              /            # (bootfs)
zroot/home         /home
zroot/usr          legacy
zroot/var          legacy
```

The other datasets will wait until the `zfs.target` systemd service is called (IF it is enabled). A dataset like `zroot/usr` will cause the kernel to complain that it can't find `/sbin/init` (`/sbin -> /usr/bin`).

Similar issue: https://github.com/demizer/archzfs/issues/22

---

These changes try to mount any *children*, with the dataset defined by the `zfs` kernel parameter. For example (`zfs=bootfs`):

```
$ zfs list -o name,mountpoint
NAME               MOUNTPOINT   
zroot/root         /            # (bootfs)
zroot/root/usr     legacy       # will get mounted (child)
zroot/root/var     legacy       # will get mounted (child)
zroot/scratch      none         # will not get mounted
zroot/home         /home        # will not get mounted
```

Legacy mountpoints get mounted if they are listed in /etc/fstab.