### PR TITLE
Rewrite the initcpio hook

### DIFF
--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -60,36 +60,26 @@ zfs_mount_handler () {
 run_hook() {
     # Force import the pools, useful if the pool has not properly been exported
     # using 'zpool export <pool>'
-    [[ $zfs_force == 1 ]] && ZPOOL_FORCE='-f'
-    [[ "$zfs_import_dir" != "" ]] && ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -d $zfs_import_dir"
+    [[ "${zfs_force}" == 1 ]] && ZPOOL_FORCE='-f'
+    [[ "${zfs_import_dir}" != "" ]] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -d ${zfs_import_dir}"
 
-    if [ "$root" = 'zfs' ]; then
-        mount_handler='zfs_mount_handler'
+    if [[ "${root}" == zfs=* ]]; then
+        ZFS_DATASET="${root#zfs=}"
+        mount_handler="zfs_mount_handler"
     fi
 
-    case $zfs in
-        "")
-            # skip this line/dataset
-            ;;
-        auto|bootfs)
-            ZFS_DATASET='bootfs'
-            mount_handler="zfs_mount_handler"
-            ;;
-        *)
-            ZFS_DATASET=$zfs
-            mount_handler="zfs_mount_handler"
-            ;;
-    esac
-
-    if [ ! -f "/etc/hostid" ] ; then
-        echo "ZFS: No hostid found on kernel command line or /etc/hostid. ZFS pools may not import correctly."
+    if [[ ! -f /etc/hostid ]] ; then
+        warning 'ZFS: No hostid found on kernel command line or /etc/hostid. ZFS pools may not import correctly.'
     fi
 
     # Allow up to 10 seconds for zfs device to show up
-    for i in 1 2 3 4 5 6 7 8 9 10; do
-        [ -c "/dev/zfs" ] && break
+    for i in {1..10}; do
+        [[ -c /dev/zfs ]] && break
         sleep 1
     done
+    if [[ ! -c /dev/zfs ]]; then
+        die 'ZFS: The /dev/zfs device did not show up in time.'
+    fi
 }
 
 run_latehook () {

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -46,12 +46,13 @@ zfs_mount_handler () {
         fi
     fi
 
-    # Support legacy mountpoints
-    local mountpoint=$(/usr/bin/zfs get -H -o value mountpoint "${ZFS_DATASET}")
-    if [[ "${mountpoint}" == legacy ]]; then
-        rwopt_exp="zfsutil,${rwopt_exp}"
-    fi
-    mount -t zfs -o "${rwopt_exp}" "${ZFS_DATASET}" "$1"
+    # Support child datasets of the root
+    local datasets=$(/usr/bin/zfs list -Ho name -t filesystem -r "${ZFS_DATASET}")
+    
+    for ds in ${datasets}; do
+        local mountpoint=$(/usr/bin/zfs get -H -o value mountpoint "${ZFS_DATASET}")
+        mount -t zfs -o "${rwopt_exp}" "${ZFS_DATASET}" "$1${mountpoint}"
+    done
 }
 
 run_hook() {

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -3,7 +3,7 @@ ZPOOL_IMPORT_FLAGS=""
 
 zfs_get_bootfs () {
     for zfs_dataset in $(/usr/bin/zpool list -H -o bootfs); do
-        case ${zfs_dataset} in
+        case "${zfs_dataset}" in
             "" | "-")
                 # skip this line/dataset
                 ;;
@@ -11,7 +11,7 @@ zfs_get_bootfs () {
                 return 1
                 ;;
             *)
-                ZFS_DATASET=${zfs_dataset}
+                ZFS_DATASET="${zfs_dataset}"
                 return 0
                 ;;
         esac

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -20,41 +20,38 @@ zfs_get_bootfs () {
 }
 
 zfs_mount_handler () {
-    local node=$1
-    if [ "$ZFS_DATASET" = "bootfs" ] ; then
-        if ! zfs_get_bootfs ; then
+    # Support readonly root
+    local rwopt_exp="${rwopt:-ro}"
+    if [[ "${rwopt_exp}" != rw ]]; then
+        ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -o readonly=on"
+    fi
+
+    # Support bootfs
+    if [[ "${ZFS_DATASET}" == bootfs ]]; then
+        if ! zfs_get_bootfs; then
             # Lets import everything and try again
-            /usr/bin/zpool import $ZPOOL_IMPORT_FLAGS -N -a $ZPOOL_FORCE
-            if ! zfs_get_bootfs ; then
-                echo "ZFS: Cannot find bootfs."
-                return 1
+            /usr/bin/zpool import -Na  "${ZPOOL_PARAMS}"
+            if ! zfs_get_bootfs; then
+                die "ZFS: Can not find bootfs."
             fi
         fi
     fi
 
     local pool="${ZFS_DATASET%%/*}"
-    local rwopt_exp=${rwopt:-ro}
 
-    if ! "/usr/bin/zpool" list -H $pool 2>&1 > /dev/null ; then
-        if [ "$rwopt_exp" != "rw" ]; then
-            msg "ZFS: Importing pool $pool readonly."
-            ZPOOL_IMPORT_FLAGS="$ZPOOL_IMPORT_FLAGS -o readonly=on"
-        else
-            msg "ZFS: Importing pool $pool."
-        fi
-
-        if ! "/usr/bin/zpool" import $ZPOOL_IMPORT_FLAGS -N $pool $ZPOOL_FORCE ; then
-            echo "ZFS: Unable to import pool $pool."
-            return 1
+    # Import pool without mounting
+    if ! /usr/bin/zpool list -H "${pool}" &>/dev/null ; then
+        if ! /usr/bin/zpool import "${ZPOOL_IMPORT_FLAGS}" -N "${pool}" "${ZPOOL_FORCE}"; then
+            die "ZFS: Unable to import pool $pool."
         fi
     fi
 
-    local mountpoint=$("/usr/bin/zfs" get -H -o value mountpoint $ZFS_DATASET)
-    if [ "$mountpoint" = "legacy" ] ; then
-        mount -t zfs -o ${rwopt_exp} "$ZFS_DATASET" "$node"
-    else
-        mount -o zfsutil,${rwopt_exp} -t zfs "$ZFS_DATASET" "$node"
+    # Support legacy mountpoints
+    local mountpoint=$(/usr/bin/zfs get -H -o value mountpoint "${ZFS_DATASET}")
+    if [[ "${mountpoint}" == legacy ]]; then
+        rwopt_exp="zfsutil,${rwopt_exp}"
     fi
+    mount -t zfs -o "${rwopt_exp}" "${ZFS_DATASET}" "$1"
 }
 
 run_hook() {

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -55,10 +55,12 @@ zfs_mount_handler () {
 }
 
 run_hook() {
+    local zfs_wait=10
     # Force import the pools, useful if the pool has not properly been exported
     # using 'zpool export <pool>'
     [[ "${zfs_force}" == 1 ]] && ZPOOL_FORCE='-f'
     [[ "${zfs_import_dir}" != "" ]] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -d ${zfs_import_dir}"
+    [[ "${zfs_wait}" != "" ]] && zfs_wait="${zfs_wait}"
 
     if [[ "${root}" == zfs=* ]]; then
         ZFS_DATASET="${root#zfs=}"
@@ -70,7 +72,7 @@ run_hook() {
     fi
 
     # Allow up to 10 seconds for zfs device to show up
-    for i in {1..10}; do
+    for i in {1..${zfs_wait}}; do
         [[ -c /dev/zfs ]] && break
         sleep 1
     done


### PR DESCRIPTION
This PR ensures a lot of variables are corretly quoted, closes some PRs, but also drops some legacy stuff.

#### Things that got better
- Variables are now quoted and use the `${}` syntax
- The script got shorter
- Support for `ro` when using `bootfs`
- Correct use of `warning` and `die`, these are functions from `mkinitcpio`
- Use of bash tests (`[[` instead of `[`), as this is recommended by the `mkinitcpio` project ([reference](https://git.archlinux.org/mkinitcpio.git/tree/HACKING))
- Mount subdatasets (see #53) of the root
- Allow customizing the timeout for `/dev/zfs` (see #49)
- Fixes the error message from #49

#### Dropped backwards compatibility
- `zfs` kernel parameter dropped
- ZFS root is now mounted with `root=zfs=bootfs` or `root=zfs=dataset/whatever`
- Messages like `Importing pool zroot` are removed, I'll add them later