### PR TITLE
Strip mountpoint from rootfs if it is not "/"

### DIFF
--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -53,6 +53,7 @@ zfs_mount_handler () {
     fi
 
     local node="$1"
+    local rootmnt=$(zfs get -H -o value mountpoint "${ZFS_DATASET}")
     local tab_file="${node}/etc/fstab"
     local zfs_datasets="$(zfs list -H -o name -t filesystem -r ${ZFS_DATASET})"
 
@@ -73,7 +74,7 @@ zfs_mount_handler () {
                 fi
                 ;;
             *)
-                mount -t zfs -o "zfsutil,${rwopt_exp}" "${dataset}" "${node}${mountpoint}"
+                mount -t zfs -o "zfsutil,${rwopt_exp}" "${dataset}" "${node}${mountpoint##${rootmnt}}"
                 ;;
         esac
     done

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -74,7 +74,7 @@ zfs_mount_handler () {
                 fi
                 ;;
             *)
-                mount -t zfs -o "zfsutil,${rwopt_exp}" "${dataset}" "${node}${mountpoint##${rootmnt}}"
+                mount -t zfs -o "zfsutil,${rwopt_exp}" "${dataset}" "${node}/${mountpoint##${rootmnt}}"
                 ;;
         esac
     done


### PR DESCRIPTION
This easily allows for multi-distro setups where each system has its own root dataset with separate mounts (e.g.: /media/Arch, /media/Gentoo, etc.).

Additionally it strips the root mountpoint from any children, so separate /usr and others will still work as expected.