### PR TITLE
update to OpenZFS version 0.6.5.11

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -1,9 +1,9 @@
 # ZFSonLinux stable version
-zol_version="0.6.5.10"
+zol_version="0.6.5.11"
 
 # The ZOL source hashes are from zfsonlinux.org
-zfs_src_hash="90a0ca76667076e9f58776216cb761f68761eb0192f8b0c45893f84cabc6f27e"
-spl_src_hash="cace7e53dd092f44e0909452dbef74adaebbe8ff0bb59b24341b0c5dafff1b45"
+zfs_src_hash="136b3061737f1a43f5310919cacbf1b8a0db72b792ef8b1606417aff16dab59d"
+spl_src_hash="ebab87a064985f93122ad82721ca54569a5ef20dc3579f84d18075210cf316ac"
 zfs_bash_completion_hash="b60214f70ffffb62ffe489cbfabd2e069d14ed2a391fac0e36f914238394b540"
 zfs_initcpio_install_hash="aa5706bf08b36209a318762680f3c9fb45b3fc4b8e4ef184c8a5370b2c3000ca"
 zfs_initcpio_hook_hash="90d50df503464e8d76770488dbd491cb633ee27984d4d3a31b03f1a4e7492038"

--- a/src/kernels/linux-lts.sh
+++ b/src/kernels/linux-lts.sh
@@ -33,36 +33,36 @@ header="\
 #
 #"
 
-# update_linux_lts_pkgbuilds() {
-    # pkg_list=("spl-utils-linux-lts" "spl-linux-lts" "zfs-utils-linux-lts" "zfs-linux-lts")
-    # kernel_version_full=$(kernel_version_full ${kernel_version})
-    # kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    # kernel_version_major=${kernel_version%-*}
-    # kernel_mod_path="${kernel_version_full}-lts"
-    # archzfs_package_group="archzfs-linux-lts"
-    # spl_pkgver=${zol_version}_${kernel_version_full_pkgver}
-    # zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
-    # spl_pkgrel=${pkgrel}
-    # zfs_pkgrel=${pkgrel}
-    # spl_utils_conflicts="'spl-utils-linux' 'spl-utils-linux-git' 'spl-utils-linux-lts-git'"
-    # spl_conflicts="'spl-utils-linux' 'spl-utils-linux-git' 'spl-linux-lts-git'"
-    # zfs_utils_conflicts="'zfs-utils-linux' 'zfs-utils-linux-git' 'zfs-utils-linux-lts-git'"
-    # zfs_conflicts="'zfs-linux' 'zfs-linux-git' 'zfs-linux-lts-git'"
-    # spl_utils_pkgname="spl-utils-linux-lts"
-    # spl_pkgname="spl-linux-lts"
-    # zfs_utils_pkgname="zfs-utils-linux-lts"
-    # zfs_pkgname="zfs-linux-lts"
-    # spl_utils_pkgbuild_path="packages/${kernel_name}/${spl_utils_pkgname}"
-    # spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
-    # zfs_utils_pkgbuild_path="packages/${kernel_name}/${zfs_utils_pkgname}"
-    # zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"
-    # spl_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/spl-${zol_version}.tar.gz"
-    # zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
-    # spl_workdir="\${srcdir}/spl-${zol_version}"
-    # zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    # linux_depends="\"linux-lts=${kernel_version_major}\""
-    # linux_headers_depends="\"linux-lts-headers=${kernel_version_major}\""
-# }
+update_linux_lts_pkgbuilds() {
+    pkg_list=("spl-utils-linux-lts" "spl-linux-lts" "zfs-utils-linux-lts" "zfs-linux-lts")
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
+    kernel_version_major=${kernel_version%-*}
+    kernel_mod_path="${kernel_version_full}-lts"
+    archzfs_package_group="archzfs-linux-lts"
+    spl_pkgver=${zol_version}_${kernel_version_full_pkgver}
+    zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
+    spl_pkgrel=${pkgrel}
+    zfs_pkgrel=${pkgrel}
+    spl_utils_conflicts="'spl-utils-linux' 'spl-utils-linux-git' 'spl-utils-linux-lts-git'"
+    spl_conflicts="'spl-utils-linux' 'spl-utils-linux-git' 'spl-linux-lts-git'"
+    zfs_utils_conflicts="'zfs-utils-linux' 'zfs-utils-linux-git' 'zfs-utils-linux-lts-git'"
+    zfs_conflicts="'zfs-linux' 'zfs-linux-git' 'zfs-linux-lts-git'"
+    spl_utils_pkgname="spl-utils-linux-lts"
+    spl_pkgname="spl-linux-lts"
+    zfs_utils_pkgname="zfs-utils-linux-lts"
+    zfs_pkgname="zfs-linux-lts"
+    spl_utils_pkgbuild_path="packages/${kernel_name}/${spl_utils_pkgname}"
+    spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
+    zfs_utils_pkgbuild_path="packages/${kernel_name}/${zfs_utils_pkgname}"
+    zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"
+    spl_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/spl-${zol_version}.tar.gz"
+    zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
+    spl_workdir="\${srcdir}/spl-${zol_version}"
+    zfs_workdir="\${srcdir}/zfs-${zol_version}"
+    linux_depends="\"linux-lts=${kernel_version_major}\""
+    linux_headers_depends="\"linux-lts-headers=${kernel_version_major}\""
+}
 
 update_linux_lts_git_pkgbuilds() {
     pkg_list=("spl-utils-linux-lts-git" "spl-linux-lts-git" "zfs-utils-linux-lts-git" "zfs-linux-lts-git")

--- a/src/kernels/linux.sh
+++ b/src/kernels/linux.sh
@@ -32,41 +32,41 @@ header="\
 # archzfs github page.
 #"
 
-# update_linux_pkgbuilds() {
-    # pkg_list=("spl-utils-linux" "spl-linux" "zfs-utils-linux" "zfs-linux")
-    # kernel_version_full=$(kernel_version_full ${kernel_version})
-    # kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    # kernel_version_major=${kernel_version%-*}
-    # kernel_mod_path="${kernel_version_full}-ARCH"
-    # archzfs_package_group="archzfs-linux"
-    # spl_pkgver=${zol_version}_${kernel_version_full_pkgver}
-    # zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
-    # spl_pkgrel=${pkgrel}
-    # zfs_pkgrel=${pkgrel}
-    # spl_utils_conflicts="'spl-utils-linux-git' 'spl-utils-linux-lts'"
-    # spl_conflicts="'spl-utils-linux-git' 'spl-utils-linux-lts'"
-    # zfs_utils_conflicts="'zfs-utils-linux-git' 'zfs-utils-linux-lts'"
-    # zfs_conflicts="'zfs-linux-git' 'zfs-linux-lts'"
-    # spl_utils_pkgname="spl-utils-linux"
-    # spl_pkgname="spl-linux"
-    # zfs_utils_pkgname="zfs-utils-linux"
-    # zfs_pkgname="zfs-linux"
-    # # Paths are relative to build.sh
-    # spl_utils_pkgbuild_path="packages/${kernel_name}/${spl_utils_pkgname}"
-    # spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
-    # zfs_utils_pkgbuild_path="packages/${kernel_name}/${zfs_utils_pkgname}"
-    # zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"
-    # spl_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/spl-${zol_version}.tar.gz"
-    # zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
-    # spl_workdir="\${srcdir}/spl-${zol_version}"
-    # zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    # linux_depends="\"linux=${kernel_version_full}\""
-    # linux_headers_depends="\"linux-headers=${kernel_version_full}\""
-    # spl_replaces='replaces=("spl-git")'
-    # spl_utils_replaces='replaces=("spl-utils-git")'
-    # zfs_replaces='replaces=("zfs-git")'
-    # zfs_utils_replaces='replaces=("zfs-utils-git")'
-# }
+update_linux_pkgbuilds() {
+    pkg_list=("spl-utils-linux" "spl-linux" "zfs-utils-linux" "zfs-linux")
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
+    kernel_version_major=${kernel_version%-*}
+    kernel_mod_path="${kernel_version_full}-ARCH"
+    archzfs_package_group="archzfs-linux"
+    spl_pkgver=${zol_version}_${kernel_version_full_pkgver}
+    zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
+    spl_pkgrel=${pkgrel}
+    zfs_pkgrel=${pkgrel}
+    spl_utils_conflicts="'spl-utils-linux-git' 'spl-utils-linux-lts'"
+    spl_conflicts="'spl-utils-linux-git' 'spl-utils-linux-lts'"
+    zfs_utils_conflicts="'zfs-utils-linux-git' 'zfs-utils-linux-lts'"
+    zfs_conflicts="'zfs-linux-git' 'zfs-linux-lts'"
+    spl_utils_pkgname="spl-utils-linux"
+    spl_pkgname="spl-linux"
+    zfs_utils_pkgname="zfs-utils-linux"
+    zfs_pkgname="zfs-linux"
+    # Paths are relative to build.sh
+    spl_utils_pkgbuild_path="packages/${kernel_name}/${spl_utils_pkgname}"
+    spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
+    zfs_utils_pkgbuild_path="packages/${kernel_name}/${zfs_utils_pkgname}"
+    zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"
+    spl_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/spl-${zol_version}.tar.gz"
+    zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
+    spl_workdir="\${srcdir}/spl-${zol_version}"
+    zfs_workdir="\${srcdir}/zfs-${zol_version}"
+    linux_depends="\"linux=${kernel_version_full}\""
+    linux_headers_depends="\"linux-headers=${kernel_version_full}\""
+    spl_replaces='replaces=("spl-git")'
+    spl_utils_replaces='replaces=("spl-utils-git")'
+    zfs_replaces='replaces=("zfs-git")'
+    zfs_utils_replaces='replaces=("zfs-utils-git")'
+}
 
 update_linux_git_pkgbuilds() {
     pkg_list=("spl-utils-linux-git" "spl-linux-git" "zfs-utils-linux-git" "zfs-linux-git")


### PR DESCRIPTION
This version does compile with gcc 7.1. So packages can finally be updated!

This fixes https://github.com/archzfs/archzfs/issues/121, fixes https://github.com/archzfs/archzfs/issues/122 and fixes https://github.com/archzfs/archzfs/issues/118