### PR TITLE
[WIP] Build extramodules

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -366,33 +366,25 @@ kernel_version_has_minor_version() {
 }
 
 
-# Returns the full kernel version. If $1 is "3.14-1" then kernel_version_full returns "3.14.0-1".
+# Returns the full kernel version. If $1 is "3.14" then kernel_version_full returns "3.14.0".
 kernel_version_full() {
     # $1: the kernel version
     local arg=$1
     if ! kernel_version_has_minor_version $1; then
         debug "kernel_version_full: Have kernel without minor version!"
-        if [[ ${1} =~ ^([[:digit:]]+\.[[:digit:]]+)\.?([[:alpha:][:digit:]]+)?\-([[:digit:]]+) ]]; then
+        if [[ ${1} =~ ^([[:digit:]]+\.[[:digit:]]+)\.?([[:alpha:][:digit:]]+)? ]]; then
             local arg=${BASH_REMATCH[1]}
             local minor=${BASH_REMATCH[2]}
             local rev=${BASH_REMATCH[3]}
             if [[ ${minor} =~ ^[[:alpha:]]+ ]]; then
-                printf "${arg}.0.${minor}-${rev}"
+                printf "${arg}.0.${minor}"
                 return 0
             fi
         fi
-        printf "${arg}.0-${rev}"
+        printf "${arg}.0"
         return 0
     fi
     printf ${arg}
-}
-
-
-# Returns the full kernel version. If $1 is "3.14-1" then kernel_version_full returns "3.14.0_1".
-kernel_version_full_no_hyphen() {
-    # $1: The full kernel version
-    # returns: output is printed to stdout
-    echo $(kernel_version_full ${1} | sed s/-/./g)
 }
 
 # from makepkg
@@ -803,7 +795,7 @@ git_calc_pkgver() {
     for repo in "spl" "zfs"; do
         msg2 "Cloning working copy for ${repo}"
         local sha=${spl_git_commit}
-        local kernvers=${kernel_version_full_pkgver}
+        local kernvers=${kernel_version_full}
         if [[ ${repo} =~ ^zfs ]]; then
             sha=${zfs_git_commit}
         fi

--- a/lib.sh
+++ b/lib.sh
@@ -473,7 +473,7 @@ check_archiso() {
         exit 155
     fi
     msg "Checking archiso download page for linux kernel version changes..."
-    check_webpage "https://www.archlinux.org/download/" "(?<=Included Kernel:</strong> )[\d\.]+" "${kernel_version::-2}"
+    check_webpage "https://www.archlinux.org/download/" "(?<=Included Kernel:</strong> )[\d\.]+" "${kernel_version}"
     check_result "archiso kernel version" "archiso" "$?"
 }
 
@@ -487,7 +487,7 @@ check_linux_hardened_kernel() {
         exit 155
     fi
     msg "Checking the online package database for x86_64 linux-hardened kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/community/x86_64/linux-hardened/" "(?<=<h2>linux-hardened )[\d\w\.-]+(?=</h2>)" "${kernel_version}"
+    check_webpage "https://www.archlinux.org/packages/community/x86_64/linux-hardened/" "(?<=<h2>linux-hardened )[\d\w\.]+(?=.\w-[\d]+</h2>)" "${kernel_version}"
     check_result "x86_64 linux-hardened kernel package" "linux-hardened x86_64" "$?"
 }
 
@@ -500,7 +500,7 @@ check_linux_zen_kernel() {
         exit 155
     fi
     msg "Checking the online package database for x86_64 linux-zen kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/extra/x86_64/linux-zen/" "(?<=<h2>linux-zen )[\d\w\.-]+(?=</h2>)" "${kernel_version}"
+    check_webpage "https://www.archlinux.org/packages/extra/x86_64/linux-zen/" "(?<=<h2>linux-zen )[\d\w\.]+(?=-[\d]+</h2>)" "${kernel_version}"
     check_result "x86_64 linux-zen kernel package" "linux-zen x86_64" "$?"
 }
 
@@ -514,7 +514,7 @@ check_linux_kernel() {
         exit 155
     fi
     msg "Checking the online package database for x86_64 linux kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/core/x86_64/linux/" "(?<=<h2>linux )[\d\.-]+(?=</h2>)" "${kernel_version}"
+    check_webpage "https://www.archlinux.org/packages/core/x86_64/linux/" "(?<=<h2>linux )[\d\.]+(?=-[\d]+</h2>)" "${kernel_version%}"
     check_result "x86_64 linux kernel package" "linux x86_64" "$?"
 }
 
@@ -528,7 +528,7 @@ check_linux_lts_kernel() {
         exit 155
     fi
     msg "Checking the online package database for x86_64 linux-lts kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/core/x86_64/linux-lts/" "(?<=<h2>linux-lts )[\d\.-]+(?=</h2>)" "${kernel_version}"
+    check_webpage "https://www.archlinux.org/packages/core/x86_64/linux-lts/" "(?<=<h2>linux-lts )[\d\.]+(?=-[\d]+</h2>)" "${kernel_version}"
     check_result "x86_64 linux-lts kernel package" "linux-lts x86_64" "$?"
 }
 

--- a/repo.sh
+++ b/repo.sh
@@ -114,9 +114,9 @@ repo_package_list() {
 
     # Get packages from the backup directory
     path="packages/${kernel_name}/{$(printf '%s,' ${pkg_list[@]} | cut -d ',' -f 1-${#pkg_list[@]})}/"
-    if [[ ! -z ${kernel_version_full_pkgver} ]]; then
-        debug "kernel_version_full_pkgver: ${kernel_version_full_pkgver}"
-        fcmd="find ${path} -iname '*${kernel_version_full_pkgver}-${spl_pkgrel}*.pkg.tar.xz' -o -iname '*${kernel_version_full_pkgver}-${zfs_pkgrel}*.pkg.tar.xz' "
+    if [[ ! -z ${kernel_version_full} ]]; then
+        debug "kernel_version_full: ${kernel_version_full}"
+        fcmd="find ${path} -iname '*${kernel_version_full}-${spl_pkgrel}*.pkg.tar.xz' -o -iname '*${kernel_version_full}-${zfs_pkgrel}*.pkg.tar.xz' "
         run_cmd_no_output_no_dry_run "${fcmd}"
         for pkg in ${run_cmd_output}; do
             pkgs+=(${pkg})
@@ -129,7 +129,7 @@ repo_package_list() {
             pkgs+=(${pkg})
         done
     else
-        debug "kernel_version_full_pkgver and spl_pkgver (and zfs_pkgver) not set!"
+        debug "kernel_version_pkgver and spl_pkgver (and zfs_pkgver) not set!"
         debug "Falling back to newest package by mod time for zfs and spl"
         for z in $(printf '%s ' ${pkg_list[@]} ); do
             # fcmd="find ${path} -iname '*${kernel_name}*-${spl_pkgrel}*.pkg.tar.xz' -o -iname '*${zfs_pkgver}-${zfs_pkgrel}*.pkg.tar.xz' "

--- a/src/kernels/archiso.sh
+++ b/src/kernels/archiso.sh
@@ -4,8 +4,9 @@ mode_desc="Select and use the packages for the archiso linux kernel"
 
 # Kernel versions for LTS packages
 pkgrel="1"
-kernel_version="4.12"
-kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
+kernel_version="4.12.8"
+kernel_version_full=$(kernel_version_full ${kernel_version})
+kernel_version_max=$(echo ${kernel_version_full}| awk -F. '{print $1"."$2"."$3+1}')
 
 header="\
 # Maintainer: Jesus Alvarez <jeezusjr at gmail dot com>
@@ -28,9 +29,9 @@ header="\
 
 update_archiso_linux_pkgbuilds() {
     pkg_list=("spl-archiso-linux" "zfs-archiso-linux")
-    kernel_mod_path="extramodules-${kernel_version}-ARCH"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-ARCH"
     archzfs_package_group="archzfs-archiso-linux"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver=${zol_version}.${kernel_version_full}
     zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}

--- a/src/kernels/archiso.sh
+++ b/src/kernels/archiso.sh
@@ -4,7 +4,8 @@ mode_desc="Select and use the packages for the archiso linux kernel"
 
 # Kernel versions for LTS packages
 pkgrel="1"
-kernel_version="4.12.8-2"
+kernel_version="4.12"
+kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
 
 header="\
 # Maintainer: Jesus Alvarez <jeezusjr at gmail dot com>
@@ -27,13 +28,11 @@ header="\
 
 update_archiso_linux_pkgbuilds() {
     pkg_list=("spl-archiso-linux" "zfs-archiso-linux")
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-ARCH"
+    kernel_mod_path="extramodules-${kernel_version}-ARCH"
     archzfs_package_group="archzfs-archiso-linux"
-    spl_pkgver=${zol_version}_${kernel_version_full_pkgver}
-    zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    spl_pkgver=${zol_version}.${kernel_version_full}
+    zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
     zfs_pkgrel=${pkgrel}
     spl_utils_pkgname="spl-utils-common>=${zol_version}"
@@ -46,7 +45,7 @@ update_archiso_linux_pkgbuilds() {
     zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
     spl_workdir="\${srcdir}/spl-${zol_version}"
     zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    linux_depends="\"linux=${kernel_version_major}\""
-    linux_headers_depends="\"linux-headers=${kernel_version_major}\""
+    linux_depends="\"linux>=${kernel_version}\" \"linux<${kernel_version_max}\""
+    linux_headers_depends="\"linux-headers>=${kernel_version}\" \"linux-headers<${kernel_version_max}\""
     zfs_makedepends="\"${spl_pkgname}-headers\""
 }

--- a/src/kernels/linux-hardened.sh
+++ b/src/kernels/linux-hardened.sh
@@ -4,8 +4,9 @@ mode_desc="Select and use the packages for the linux-hardened kernel"
 
 # Kernel versions for hardened packages
 pkgrel="1"
-kernel_version="4.13"
-kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
+kernel_version="4.13.3"
+kernel_version_full=$(kernel_version_full ${kernel_version})
+kernel_version_max=$(echo ${kernel_version_full}| awk -F. '{print $1"."$2"."$3+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
@@ -37,9 +38,9 @@ header="\
 
 update_linux_hardened_pkgbuilds() {
     pkg_list=("spl-linux-hardened" "zfs-linux-hardened")
-    kernel_mod_path="extramodules-${kernel_version}-hardened"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-hardened"
     archzfs_package_group="archzfs-linux-hardened"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver=${zol_version}.${kernel_version_full}
     zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
@@ -65,9 +66,9 @@ update_linux_hardened_git_pkgbuilds() {
     pkg_list=("spl-linux-hardened-git" "zfs-linux-hardened-git")
     kernel_version=${kernel_version_git}
     kernel_version_max=${kernel_version_max_git}
-    kernel_mod_path="extramodules-${kernel_version}-hardened"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-hardened"
     archzfs_package_group="archzfs-linux-hardened-git"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}

--- a/src/kernels/linux-hardened.sh
+++ b/src/kernels/linux-hardened.sh
@@ -4,11 +4,13 @@ mode_desc="Select and use the packages for the linux-hardened kernel"
 
 # Kernel versions for hardened packages
 pkgrel="1"
-kernel_version="4.13.3.a-1"
+kernel_version="4.13"
+kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
 kernel_version_git="${kernel_version}"
+kernel_version_max_git="${kernel_version_max}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -35,13 +37,11 @@ header="\
 
 update_linux_hardened_pkgbuilds() {
     pkg_list=("spl-linux-hardened" "zfs-linux-hardened")
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full/\.[a-z]/}-hardened"
+    kernel_mod_path="extramodules-${kernel_version}-hardened"
     archzfs_package_group="archzfs-linux-hardened"
-    spl_pkgver=${zol_version}_${kernel_version_full_pkgver}
-    zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    spl_pkgver=${zol_version}.${kernel_version_full}
+    zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
     zfs_pkgrel=${pkgrel}
     spl_conflicts="'spl-linux-hardened-git'"
@@ -56,19 +56,18 @@ update_linux_hardened_pkgbuilds() {
     zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
     spl_workdir="\${srcdir}/spl-${zol_version}"
     zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    linux_depends="\"linux-hardened=${kernel_version}\""
-    linux_headers_depends="\"linux-hardened-headers=${kernel_version}\""
+    linux_depends="\"linux-hardened>=${kernel_version}\" \"linux-hardened<${kernel_version_max}\""
+    linux_headers_depends="\"linux-hardened-headers>=${kernel_version}\" \"linux-hardened-headers<${kernel_version_max}\""
     zfs_makedepends="\"${spl_pkgname}-headers\""
 }
 
 update_linux_hardened_git_pkgbuilds() {
     pkg_list=("spl-linux-hardened-git" "zfs-linux-hardened-git")
     kernel_version=${kernel_version_git}
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full/\.[a-z]/}-hardened"
+    kernel_version_max=${kernel_version_max_git}
+    kernel_mod_path="extramodules-${kernel_version}-hardened"
     archzfs_package_group="archzfs-linux-hardened-git"
+    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}
@@ -84,8 +83,8 @@ update_linux_hardened_git_pkgbuilds() {
         spl_src_target="git+${spl_git_url}#commit=${spl_git_commit}"
     fi
     spl_src_hash="SKIP"
-    linux_depends="\"linux-hardened=${kernel_version}\""
-    linux_headers_depends="\"linux-hardened-headers=${kernel_version}\""
+    linux_depends="\"linux-hardened>=${kernel_version}\" \"linux-hardened<${kernel_version_max}\""
+    linux_headers_depends="\"linux-hardened-headers>=${kernel_version}\" \"linux-hardened-headers<${kernel_version_max}\""
     spl_makedepends="\"git\""
     zfs_src_target="git+${zfs_git_url}"
     if [[ ${zfs_git_commit} != "" ]]; then

--- a/src/kernels/linux-lts.sh
+++ b/src/kernels/linux-lts.sh
@@ -4,11 +4,13 @@ mode_desc="Select and use the packages for the linux-lts kernel"
 
 # Kernel versions for LTS packages
 pkgrel="1"
-kernel_version="4.9.51-1"
+kernel_version="4.9"
+kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
 kernel_version_git="${kernel_version}"
+kernel_version_max_git="${kernel_version_max}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -35,13 +37,11 @@ header="\
 
 update_linux_lts_pkgbuilds() {
     pkg_list=("spl-linux-lts" "zfs-linux-lts")
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-lts"
+    kernel_mod_path="extramodules-${kernel_version}-lts"
     archzfs_package_group="archzfs-linux-lts"
-    spl_pkgver=${zol_version}.${kernel_version_full_pkgver}
-    zfs_pkgver=${zol_version}.${kernel_version_full_pkgver}
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    spl_pkgver=${zol_version}.${kernel_version_full}
+    zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
     zfs_pkgrel=${pkgrel}
     spl_conflicts="'spl-linux-lts-git'"
@@ -57,8 +57,8 @@ update_linux_lts_pkgbuilds() {
     zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
     spl_workdir="\${srcdir}/spl-${zol_version}"
     zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    linux_depends="\"linux-lts=${kernel_version_major}\""
-    linux_headers_depends="\"linux-lts-headers=${kernel_version_major}\""
+    linux_depends="\"linux-lts>=${kernel_version}\" \"linux-lts<${kernel_version_max}\""
+    linux_headers_depends="\"linux-lts-headers>=${kernel_version}\" \"linux-lts-headers<${kernel_version_max}\""
     spl_makedepends="\"libelf\""
     zfs_makedepends="\"libelf\" \"${spl_pkgname}-headers\""
 }
@@ -66,11 +66,9 @@ update_linux_lts_pkgbuilds() {
 update_linux_lts_git_pkgbuilds() {
     pkg_list=("spl-linux-lts-git" "zfs-linux-lts-git")
     kernel_version=${kernel_version_git}
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-lts"
+    kernel_mod_path="extramodules-${kernel_version}-lts"
     archzfs_package_group="archzfs-linux-lts-git"
+    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}
@@ -86,8 +84,8 @@ update_linux_lts_git_pkgbuilds() {
         spl_src_target="git+${spl_git_url}#commit=${spl_git_commit}"
     fi
     spl_src_hash="SKIP"
-    linux_depends="\"linux-lts=${kernel_version_full}\""
-    linux_headers_depends="\"linux-lts-headers=${kernel_version_full}\""
+    linux_depends="\"linux-lts>=${kernel_version}\" \"linux-lts<${kernel_version_max}\""
+    linux_headers_depends="\"linux-lts-headers>=${kernel_version}\" \"linux-lts-headers<${kernel_version_max}\""
     spl_makedepends="\"libelf\" \"git\""
     zfs_src_target="git+${zfs_git_url}"
     if [[ ${zfs_git_commit} != "" ]]; then

--- a/src/kernels/linux-lts.sh
+++ b/src/kernels/linux-lts.sh
@@ -4,8 +4,9 @@ mode_desc="Select and use the packages for the linux-lts kernel"
 
 # Kernel versions for LTS packages
 pkgrel="1"
-kernel_version="4.9"
-kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
+kernel_version="4.9.51"
+kernel_version_full=$(kernel_version_full ${kernel_version})
+kernel_version_max=$(echo ${kernel_version_full}| awk -F. '{print $1"."$2"."$3+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
@@ -37,9 +38,9 @@ header="\
 
 update_linux_lts_pkgbuilds() {
     pkg_list=("spl-linux-lts" "zfs-linux-lts")
-    kernel_mod_path="extramodules-${kernel_version}-lts"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-lts"
     archzfs_package_group="archzfs-linux-lts"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver=${zol_version}.${kernel_version_full}
     zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
@@ -66,9 +67,9 @@ update_linux_lts_pkgbuilds() {
 update_linux_lts_git_pkgbuilds() {
     pkg_list=("spl-linux-lts-git" "zfs-linux-lts-git")
     kernel_version=${kernel_version_git}
-    kernel_mod_path="extramodules-${kernel_version}-lts"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-lts"
     archzfs_package_group="archzfs-linux-lts-git"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}

--- a/src/kernels/linux-zen.sh
+++ b/src/kernels/linux-zen.sh
@@ -4,11 +4,13 @@ mode_desc="Select and use the packages for the linux-zen kernel"
 
 # Kernel versions for default ZFS packages
 pkgrel="1"
-kernel_version="4.13.3-1"
+kernel_version="4.13"
+kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
 kernel_version_git="${kernel_version}"
+kernel_version_max_git="${kernel_version_max}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -34,13 +36,11 @@ header="\
 
 update_linux_pkgbuilds() {
     pkg_list=("spl-linux-zen" "zfs-linux-zen")
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-zen"
+    kernel_mod_path="extramodules-${kernel_version}-zen"
     archzfs_package_group="archzfs-linux-zen"
-    spl_pkgver=${zol_version}.${kernel_version_full_pkgver}
-    zfs_pkgver=${zol_version}.${kernel_version_full_pkgver}
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    spl_pkgver=${zol_version}.${kernel_version_full}
+    zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
     zfs_pkgrel=${pkgrel}
     spl_conflicts="'spl-linux-zen-git'"
@@ -56,19 +56,18 @@ update_linux_pkgbuilds() {
     zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
     spl_workdir="\${srcdir}/spl-${zol_version}"
     zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    linux_depends="\"linux-zen=${kernel_version_full}\""
-    linux_headers_depends="\"linux-zen-headers=${kernel_version_full}\""
+    linux_depends="\"linux-zen>=${kernel_version}\" \"linux-zen<${kernel_version_max}\""
+    linux_headers_depends="\"linux-zen-headers>=${kernel_version}\" \"linux-zen-headers<${kernel_version_max}\""
     zfs_makedepends="\"${spl_pkgname}-headers\""
 }
 
 update_linux_git_pkgbuilds() {
     pkg_list=("spl-linux-zen-git" "zfs-linux-zen-git")
     kernel_version=${kernel_version_git}
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-zen"
+    kernel_version_max=${kernel_version_max_git}
+    kernel_mod_path="extramodules-${kernel_version}-zen"
     archzfs_package_group="archzfs-linux-zen-git"
+    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}
@@ -84,8 +83,8 @@ update_linux_git_pkgbuilds() {
         spl_src_target="git+${spl_git_url}#commit=${spl_git_commit}"
     fi
     spl_src_hash="SKIP"
-    linux_depends="\"linux-zen=${kernel_version_full}\""
-    linux_headers_depends="\"linux-zen-headers=${kernel_version_full}\""
+    linux_depends="\"linux-zen>=${kernel_version}\" \"linux-zen<${kernel_version_max}\""
+    linux_headers_depends="\"linux-zen-headers>=${kernel_version}\" \"linux-zen-headers<${kernel_version_max}\""
     spl_makedepends="\"git\""
     zfs_src_target="git+${zfs_git_url}"
     if [[ ${zfs_git_commit} != "" ]]; then

--- a/src/kernels/linux-zen.sh
+++ b/src/kernels/linux-zen.sh
@@ -4,8 +4,9 @@ mode_desc="Select and use the packages for the linux-zen kernel"
 
 # Kernel versions for default ZFS packages
 pkgrel="1"
-kernel_version="4.13"
-kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
+kernel_version="4.13.3"
+kernel_version_full=$(kernel_version_full ${kernel_version})
+kernel_version_max=$(echo ${kernel_version_full}| awk -F. '{print $1"."$2"."$3+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
@@ -36,9 +37,9 @@ header="\
 
 update_linux_pkgbuilds() {
     pkg_list=("spl-linux-zen" "zfs-linux-zen")
-    kernel_mod_path="extramodules-${kernel_version}-zen"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-zen"
     archzfs_package_group="archzfs-linux-zen"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver=${zol_version}.${kernel_version_full}
     zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
@@ -65,9 +66,9 @@ update_linux_git_pkgbuilds() {
     pkg_list=("spl-linux-zen-git" "zfs-linux-zen-git")
     kernel_version=${kernel_version_git}
     kernel_version_max=${kernel_version_max_git}
-    kernel_mod_path="extramodules-${kernel_version}-zen"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-zen"
     archzfs_package_group="archzfs-linux-zen-git"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}

--- a/src/kernels/linux.sh
+++ b/src/kernels/linux.sh
@@ -4,8 +4,9 @@ mode_desc="Select and use the packages for the default linux kernel"
 
 # Kernel versions for default ZFS packages
 pkgrel="1"
-kernel_version="4.12"
-kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
+kernel_version="4.12.13"
+kernel_version_full=$(kernel_version_full ${kernel_version})
+kernel_version_max=$(echo ${kernel_version_full}| awk -F. '{print $1"."$2"."$3+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
@@ -36,9 +37,9 @@ header="\
 
 update_linux_pkgbuilds() {
     pkg_list=("spl-linux" "zfs-linux")
-    kernel_mod_path="extramodules-${kernel_version}-ARCH"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-ARCH"
     archzfs_package_group="archzfs-linux"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver=${zol_version}.${kernel_version_full}
     zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
@@ -67,9 +68,9 @@ update_linux_git_pkgbuilds() {
     pkg_list=("spl-linux-git" "zfs-linux-git")
     kernel_version=${kernel_version_git}
     kernel_version_max=${kernel_version_max_git}
-    kernel_mod_path="extramodules-${kernel_version}-ARCH"
+    kernel_version_major=${kernel_version_full%\.*}
+    kernel_mod_path="extramodules-${kernel_version_major}-ARCH"
     archzfs_package_group="archzfs-linux-git"
-    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}

--- a/src/kernels/linux.sh
+++ b/src/kernels/linux.sh
@@ -4,11 +4,13 @@ mode_desc="Select and use the packages for the default linux kernel"
 
 # Kernel versions for default ZFS packages
 pkgrel="1"
-kernel_version="4.12.13-1"
+kernel_version="4.12"
+kernel_version_max=$(echo ${kernel_version}| awk -F. '{print $1"."$2+1}')
 
 # Kernel version for GIT packages
 pkgrel_git="${pkgrel}"
 kernel_version_git="${kernel_version}"
+kernel_version_max_git="${kernel_version_max}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -34,13 +36,11 @@ header="\
 
 update_linux_pkgbuilds() {
     pkg_list=("spl-linux" "zfs-linux")
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-ARCH"
+    kernel_mod_path="extramodules-${kernel_version}-ARCH"
     archzfs_package_group="archzfs-linux"
-    spl_pkgver=${zol_version}.${kernel_version_full_pkgver}
-    zfs_pkgver=${zol_version}.${kernel_version_full_pkgver}
+    kernel_version_full=$(kernel_version_full ${kernel_version})
+    spl_pkgver=${zol_version}.${kernel_version_full}
+    zfs_pkgver=${zol_version}.${kernel_version_full}
     spl_pkgrel=${pkgrel}
     zfs_pkgrel=${pkgrel}
     spl_conflicts="'spl-linux-git'"
@@ -56,8 +56,8 @@ update_linux_pkgbuilds() {
     zfs_src_target="https://github.com/zfsonlinux/zfs/releases/download/zfs-${zol_version}/zfs-${zol_version}.tar.gz"
     spl_workdir="\${srcdir}/spl-${zol_version}"
     zfs_workdir="\${srcdir}/zfs-${zol_version}"
-    linux_depends="\"linux=${kernel_version_full}\""
-    linux_headers_depends="\"linux-headers=${kernel_version_full}\""
+    linux_depends="\"linux>=${kernel_version}\" \"linux<${kernel_version_max}\""
+    linux_headers_depends="\"linux-headers>=${kernel_version}\" \"linux-headers<${kernel_version_max}\""
     spl_replaces='replaces=("spl-git")'
     zfs_replaces='replaces=("zfs-git")'
     zfs_makedepends="\"${spl_pkgname}-headers\""
@@ -66,11 +66,10 @@ update_linux_pkgbuilds() {
 update_linux_git_pkgbuilds() {
     pkg_list=("spl-linux-git" "zfs-linux-git")
     kernel_version=${kernel_version_git}
-    kernel_version_full=$(kernel_version_full ${kernel_version})
-    kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
-    kernel_version_major=${kernel_version%-*}
-    kernel_mod_path="${kernel_version_full}-ARCH"
+    kernel_version_max=${kernel_version_max_git}
+    kernel_mod_path="extramodules-${kernel_version}-ARCH"
     archzfs_package_group="archzfs-linux-git"
+    kernel_version_full=$(kernel_version_full ${kernel_version})
     spl_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     spl_pkgrel=${pkgrel_git}
@@ -86,8 +85,8 @@ update_linux_git_pkgbuilds() {
         spl_src_target="git+${spl_git_url}#commit=${spl_git_commit}"
     fi
     spl_src_hash="SKIP"
-    linux_depends="\"linux=${kernel_version_full}\""
-    linux_headers_depends="\"linux-headers=${kernel_version_full}\""
+    linux_depends="\"linux>=${kernel_version}\" \"linux<${kernel_version_max}\""
+    linux_headers_depends="\"linux-headers>=${kernel_version}\" \"linux-headers<${kernel_version_max}\""
     spl_makedepends="\"git\""
     zfs_src_target="git+${zfs_git_url}"
     if [[ ${zfs_git_commit} != "" ]]; then

--- a/src/spl/PKGBUILD.sh
+++ b/src/spl/PKGBUILD.sh
@@ -6,7 +6,7 @@ pkgbase="${spl_pkgname}"
 pkgname=("${spl_pkgname}" "${spl_pkgname}-headers")
 pkgver=${spl_pkgver}
 pkgrel=${spl_pkgrel}
-makedepends=(${linux_headers_depends} ${spl_makedepends})
+makedepends=(${linux_headers_depends} ${linux_depends} ${spl_makedepends})
 arch=("x86_64")
 url="http://zfsonlinux.org/"
 source=("${spl_src_target}")
@@ -15,16 +15,18 @@ license=("GPL")
 depends=("${spl_utils_pkgname}" "kmod" ${linux_depends})
 
 build() {
+    _kernver="\$(cat /usr/lib/modules/${kernel_mod_path}/version)"
     cd "${spl_workdir}"
     ./autogen.sh
     ./configure --prefix=/usr --libdir=/usr/lib --sbindir=/usr/bin \\
-                --with-linux=/usr/lib/modules/${kernel_mod_path}/build \\
-                --with-linux-obj=/usr/lib/modules/${kernel_mod_path}/build \\
+                --with-linux=/usr/lib/modules/\${_kernver}/build \\
+                --with-linux-obj=/usr/lib/modules/\${_kernver}/build \\
                 --with-config=kernel
     make
 }
 
 package_${spl_pkgname}() {
+    _kernver="\$(cat /usr/lib/modules/${kernel_mod_path}/version)"
     pkgdesc="Solaris Porting Layer kernel modules."
     install=spl.install
     provides=("spl")
@@ -36,11 +38,15 @@ package_${spl_pkgname}() {
     make DESTDIR="\${pkgdir}" install
     mv "\${pkgdir}/lib" "\${pkgdir}/usr/"
 
+    mv "\${pkgdir}/usr/lib/modules/\${_kernver}/extra" "\${pkgdir}/usr/lib/modules/${kernel_mod_path}"
+    rm -r "\${pkgdir}/usr/lib/modules/\${_kernver}"
+
     # Remove src dir
     rm -r "\${pkgdir}"/usr/src
 }
 
 package_${spl_pkgname}-headers() {
+    _kernver="\$(cat /usr/lib/modules/${kernel_mod_path}/version)"
     pkgdesc="Solaris Porting Layer kernel headers."
     conflicts=(${spl_headers_conflicts})
 
@@ -49,13 +55,13 @@ package_${spl_pkgname}-headers() {
     rm -r "\${pkgdir}/lib"
 
     # Remove reference to \${srcdir}
-    sed -i "s+\${srcdir}++" \${pkgdir}/usr/src/spl-*/${kernel_mod_path}/Module.symvers
+    sed -i "s+\${srcdir}++" \${pkgdir}/usr/src/spl-*/\${_kernver}/Module.symvers
 }
 
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-    sed -i "/^build()/i pkgver() {\n    cd \"${spl_workdir}\"\n    echo \$(git describe --long | sed 's/^spl-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g').${kernel_version_full_pkgver}\n}" ${spl_pkgbuild_path}/PKGBUILD
+    sed -i "/^build()/i pkgver() {\n    cd \"${spl_workdir}\"\n    echo \$(git describe --long | sed 's/^spl-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g').${kernel_version_full}\n}" ${spl_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${spl_pkgbuild_path}/PKGBUILD"

--- a/src/spl/spl.install.sh
+++ b/src/spl/spl.install.sh
@@ -15,6 +15,6 @@ post_upgrade() {
 
 run_depmod() {
     echo ">>> Updating SPL module dependencies"
-    depmod -a ${kernel_mod_path}
+    depmod -a \$(cat /usr/lib/modules/${kernel_mod_path}/version)
 }
 EOF

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -6,7 +6,7 @@ pkgbase="${zfs_pkgname}"
 pkgname=("${zfs_pkgname}" "${zfs_pkgname}-headers")
 pkgver=${zfs_pkgver}
 pkgrel=${zfs_pkgrel}
-makedepends=(${linux_headers_depends} ${zfs_makedepends})
+makedepends=(${linux_headers_depends} ${linux_depends} ${zfs_makedepends})
 arch=("x86_64")
 url="http://zfsonlinux.org/"
 source=("${zfs_src_target}")
@@ -15,17 +15,19 @@ license=("CDDL")
 depends=("kmod" "${spl_pkgname}" "${zfs_utils_pkgname}" ${linux_depends})
 
 build() {
+    _kernver="\$(cat /usr/lib/modules/${kernel_mod_path}/version)"
     cd "${zfs_workdir}"
     ./autogen.sh
     ./configure --prefix=/usr --sysconfdir=/etc --sbindir=/usr/bin --libdir=/usr/lib \\
                 --datadir=/usr/share --includedir=/usr/include --with-udevdir=/lib/udev \\
                 --libexecdir=/usr/lib/zfs-${zol_version} --with-config=kernel \\
-                --with-linux=/usr/lib/modules/${kernel_mod_path}/build \\
-                --with-linux-obj=/usr/lib/modules/${kernel_mod_path}/build
+                --with-linux=/usr/lib/modules/\${_kernver}/build \\
+                --with-linux-obj=/usr/lib/modules/\${_kernver}/build
     make
 }
 
 package_${zfs_pkgname}() {
+    _kernver="\$(cat /usr/lib/modules/${kernel_mod_path}/version)"
     pkgdesc="Kernel modules for the Zettabyte File System."
     install=zfs.install
     provides=("zfs")
@@ -38,11 +40,15 @@ package_${zfs_pkgname}() {
     cp -r "\${pkgdir}"/{lib,usr}
     rm -r "\${pkgdir}"/lib
 
+    mv "\${pkgdir}/usr/lib/modules/\${_kernver}/extra" "\${pkgdir}/usr/lib/modules/${kernel_mod_path}"
+    rm -r "\${pkgdir}/usr/lib/modules/\${_kernver}"
+
     # Remove src dir
     rm -r "\${pkgdir}"/usr/src
 }
 
 package_${zfs_pkgname}-headers() {
+    _kernver="\$(cat /usr/lib/modules/${kernel_mod_path}/version)"
     pkgdesc="Kernel headers for the Zettabyte File System."
     conflicts=(${zfs_headers_conflicts})
 
@@ -51,13 +57,13 @@ package_${zfs_pkgname}-headers() {
     rm -r "\${pkgdir}/lib"
 
     # Remove reference to \${srcdir}
-    sed -i "s+\${srcdir}++" \${pkgdir}/usr/src/zfs-*/${kernel_mod_path}/Module.symvers
+    sed -i "s+\${srcdir}++" \${pkgdir}/usr/src/zfs-*/\${_kernver}/Module.symvers
 }
 
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    echo \$(git describe --long | sed 's/^zfs-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g').${kernel_version_full_pkgver}\n}" ${zfs_pkgbuild_path}/PKGBUILD
+	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    echo \$(git describe --long | sed 's/^zfs-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g').${kernel_version_full}\n}" ${zfs_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${zfs_pkgbuild_path}/PKGBUILD"

--- a/src/zfs/zfs.install.sh
+++ b/src/zfs/zfs.install.sh
@@ -15,7 +15,8 @@ post_upgrade() {
 
 check_initramfs() {
     echo ">>> Updating ZFS module dependencies"
-    depmod -a ${kernel_mod_path}
+    depmod -a \$(cat /usr/lib/modules/${kernel_mod_path}/version)
+    
     MK_CONF=\$(grep -v '#' /etc/mkinitcpio.conf | grep zfs >/dev/null; echo \$?);
     if [[ \${MK_CONF} == '0' && \$1 == 'remove' ]]; then
         echo '>>> The ZFS packages have been removed, but "zfs" remains in the "hooks"'


### PR DESCRIPTION
Depends on: https://github.com/archzfs/archzfs/pull/129
Closes https://github.com/archzfs/archzfs/issues/92

I added support for building extramodules, which will allow to target multiple point releases of a kernel without having to update zfs all the time. So if the linux package for example gets update from 4.11.2 to 4.11.3, you don't have to wait for an updated package in archzfs.

This is based on some of your work (8f4d83b).
As said previously: If you would rather continue your version of extramodules, don't hesitate on closing this merge request. I do this mostly because I'm learning Bash and more about Arch Linux along the way

At this point, this is experimental, since while updating from linux-lts-4.9.36 to 4.9.37 did work flawlessly, an update from linux-hardened 4.12.e to 4.12.1.a did break unfortunately. Might be a problem with linux-hardened though.

I did also create a test repo, with all theses changes
Just replace the archzfs one with this:
```
[zfs-test]
SigLevel = Never
Server = https://arch.et.tc/$repo
```
You might need to "downgrade" some packages with pacman -Syuu, since the version numbers are lower.