### PR TITLE
set OpenZFS version 0.7.0

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -1,9 +1,9 @@
 # ZFSonLinux stable version
-zol_version="0.6.5.11"
+zol_version="0.7.0"
 
 # The ZOL source hashes are from zfsonlinux.org
-zfs_src_hash="136b3061737f1a43f5310919cacbf1b8a0db72b792ef8b1606417aff16dab59d"
-spl_src_hash="ebab87a064985f93122ad82721ca54569a5ef20dc3579f84d18075210cf316ac"
+zfs_src_hash="6907524f5ca4149b799fe65cd31b552b0ae90dba5dc20524e1a24fc708d807d2"
+spl_src_hash="567f461435f99f862efb1b740ed0876b52a2a539aafad6e5372a84a06a5da4d3"
 zfs_bash_completion_hash="b60214f70ffffb62ffe489cbfabd2e069d14ed2a391fac0e36f914238394b540"
 zfs_initcpio_install_hash="aa5706bf08b36209a318762680f3c9fb45b3fc4b8e4ef184c8a5370b2c3000ca"
 zfs_initcpio_hook_hash="2bb533db561992c861bb9acad64a127f81cf0e4bf39cb4308ac7a73a17db55a7"


### PR DESCRIPTION
Closes https://github.com/archzfs/archzfs/issues/137

I got the test scripts working, and had no errors. I ran `archzfs-qemu-lts-test-00-bootfs` and `archzfs-qemu-std-test-00-bootfs`
I could start the resulting images and login with no problems.