### PR TITLE
Update archiso packages for kernel 4.12.3-1

### DIFF
--- a/src/kernels/archiso.sh
+++ b/src/kernels/archiso.sh
@@ -4,7 +4,7 @@ mode_desc="Select and use the packages for the archiso linux kernel"
 
 # Kernel versions for LTS packages
 pkgrel="1"
-kernel_version="4.7.2-1"
+kernel_version="4.12.3-1"
 
 header="\
 # Maintainer: Jesus Alvarez <jeezusjr at gmail dot com>


### PR DESCRIPTION
New archiso was generated today. Don't know if you still build packages for this. 

fixes #115