### PR TITLE
Fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -237,7 +237,6 @@ build_packages() {
             # run_cmd "tree ${chroot_path}/build/${pkg}/pkg"
             # exit
         # fi
-        exit 1
     done
     run_cmd "find . -iname \"*.log\" -print -exec rm {} \\;"
 }


### PR DESCRIPTION
An `exit 1` has been added in 9136ed6c6f811d2c6dfe977989d5ff8c41f28a30. This prevents building more than one package per run.