### PR TITLE
Fix dependency to fixed common-utils versions

### DIFF
--- a/src/kernels/archiso.sh
+++ b/src/kernels/archiso.sh
@@ -36,9 +36,9 @@ update_archiso_linux_pkgbuilds() {
     zfs_pkgver=${zol_version}_${kernel_version_full_pkgver}
     spl_pkgrel=${pkgrel}
     zfs_pkgrel=${pkgrel}
-    spl_utils_pkgname="spl-utils-common>=${zol_version}"
+    spl_utils_pkgname="spl-utils-common=${zol_version}"
     spl_pkgname="spl-archiso-linux"
-    zfs_utils_pkgname="zfs-utils-common>=${zol_version}"
+    zfs_utils_pkgname="zfs-utils-common=${zol_version}"
     zfs_pkgname="zfs-archiso-linux"
     spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
     zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"

--- a/src/kernels/dkms.sh
+++ b/src/kernels/dkms.sh
@@ -34,8 +34,8 @@ update_dkms_pkgbuilds() {
     zfs_conflicts="'zfs-dkms-git'"
     spl_pkgname="spl-dkms"
     zfs_pkgname="zfs-dkms"
-    spl_utils_pkgname="spl-utils-common>=${zol_version}"
-    zfs_utils_pkgname="zfs-utils-common>=${zol_version}"
+    spl_utils_pkgname="spl-utils-common=${zol_version}"
+    zfs_utils_pkgname="zfs-utils-common=${zol_version}"
     # Paths are relative to build.sh
     spl_dkms_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
     zfs_dkms_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"

--- a/src/kernels/linux-hardened.sh
+++ b/src/kernels/linux-hardened.sh
@@ -46,9 +46,9 @@ update_linux_hardened_pkgbuilds() {
     zfs_pkgrel=${pkgrel}
     spl_conflicts="'spl-linux-hardened-git'"
     zfs_conflicts="'zfs-linux-hardened-git'"
-    spl_utils_pkgname="spl-utils-common>=${zol_version}"
+    spl_utils_pkgname="spl-utils-common=${zol_version}"
     spl_pkgname="spl-linux-hardened"
-    zfs_utils_pkgname="zfs-utils-common>=${zol_version}"
+    zfs_utils_pkgname="zfs-utils-common=${zol_version}"
     zfs_pkgname="zfs-linux-hardened"
     spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
     zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"

--- a/src/kernels/linux-lts.sh
+++ b/src/kernels/linux-lts.sh
@@ -47,9 +47,9 @@ update_linux_lts_pkgbuilds() {
     spl_conflicts="'spl-linux-lts-git'"
     zfs_conflicts="'zfs-linux-lts-git'"
     spl_pkgname="spl-linux-lts"
-    spl_utils_pkgname="spl-utils-common>=${zol_version}"
+    spl_utils_pkgname="spl-utils-common=${zol_version}"
     zfs_pkgname="zfs-linux-lts"
-    zfs_utils_pkgname="zfs-utils-common>=${zol_version}"
+    zfs_utils_pkgname="zfs-utils-common=${zol_version}"
     # Paths are relative to build.sh
     spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
     zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"

--- a/src/kernels/linux-zen.sh
+++ b/src/kernels/linux-zen.sh
@@ -45,9 +45,9 @@ update_linux_pkgbuilds() {
     zfs_pkgrel=${pkgrel}
     spl_conflicts="'spl-linux-zen-git'"
     zfs_conflicts="'zfs-linux-zen-git'"
-    spl_utils_pkgname="spl-utils-common>=${zol_version}"
+    spl_utils_pkgname="spl-utils-common=${zol_version}"
     spl_pkgname="spl-linux-zen"
-    zfs_utils_pkgname="zfs-utils-common>=${zol_version}"
+    zfs_utils_pkgname="zfs-utils-common=${zol_version}"
     zfs_pkgname="zfs-linux-zen"
     # Paths are relative to build.sh
     spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"

--- a/src/kernels/linux.sh
+++ b/src/kernels/linux.sh
@@ -46,9 +46,9 @@ update_linux_pkgbuilds() {
     spl_conflicts="'spl-linux-git'"
     zfs_conflicts="'zfs-linux-git'"
     spl_pkgname="spl-linux"
-    spl_utils_pkgname="spl-utils-common>=${zol_version}"
+    spl_utils_pkgname="spl-utils-common=${zol_version}"
     zfs_pkgname="zfs-linux"
-    zfs_utils_pkgname="zfs-utils-common>=${zol_version}"
+    zfs_utils_pkgname="zfs-utils-common=${zol_version}"
     # Paths are relative to build.sh
     spl_pkgbuild_path="packages/${kernel_name}/${spl_pkgname}"
     zfs_pkgbuild_path="packages/${kernel_name}/${zfs_pkgname}"


### PR DESCRIPTION
Fixes #188 

@demizer, you would still need to manually push all `git` packages at once, but this will disallow the installation of mismatched versions if they get into the repo.

However: It will make it harder for people, who build the packages manually using the aur, since they need to install `zfs-utils-common` and `zfs-<kernel>` in one operation to not break the dependency.
```
error: failed to prepare transaction (could not satisfy dependencies)
:: zfs-linux: installing zfs-common (0.7.2-1) breaks dependency 'zfs-common=0.7.1'
```