### PR TITLE
Improvements for automated deployment

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -28,8 +28,5 @@ gpg_sign_key='0EE7A126'
 
 chroot_path="/repo/chroot/x86_64/$(whoami)"
 
-# Package backup directory
-package_backup_dir="/repo/archive_archzfs"
-
 # Used to run mkaurball and mksrcinfo with lower privledges
 makepkg_nonpriv_user="demizer"

--- a/conf.sh
+++ b/conf.sh
@@ -18,6 +18,7 @@ email="jeezusjr@gmail.com"
 # Repository path and name
 repo_basename="archzfs"
 repo_basepath="/repo"
+repo_remote_basepath="/home/jalvarez/webapps/default"
 
 # SSH login address (can use ssh config Hosts)
 remote_login="webfaction"

--- a/conf.sh
+++ b/conf.sh
@@ -16,9 +16,8 @@ zfs_initcpio_hook_hash="3eb874cf2cbb6c6a0e1c11a98af54f682d6225667af944b43435aeab
 email="jeezusjr@gmail.com"
 
 # Repository path and name
-repo_name="archzfs"
+repo_basename="archzfs"
 repo_basepath="/repo"
-repo_name_test="archzfs-testing"
 
 # SSH login address (can use ssh config Hosts)
 remote_login="webfaction"

--- a/lib.sh
+++ b/lib.sh
@@ -444,13 +444,11 @@ check_internet() {
 }
 
 
-check_webpage() {
+get_webpage() {
     # $1: The url to scrape
     # $2: The Perl regex to match with
-    # $3: Expect match
     debug "Checking webpage: $1"
     debug "Using regex: `printf "%q" "$2"`"
-    debug "Expecting: $3"
 
     run_cmd_no_output "curl -sL ${1}"
 
@@ -468,11 +466,23 @@ check_webpage() {
         return 55
     fi
 
-    local scraped_string=$(echo "${run_cmd_output}" | \grep -Po -m 1 "${2}")
-    debug "Got \"${scraped_string}\" from webpage."
+    webpage_output=$(echo "${run_cmd_output}" | \grep -Po -m 1 "${2}")
+    debug "Got \"${webpage_output}\" from webpage."
+}
 
-    if [[ ${scraped_string} != "$3" ]]; then
-        error "Checking '$1' expected '$3' got '${scraped_string}'"
+check_webpage() {
+    # $1: The url to scrape
+    # $2: The Perl regex to match with
+    # $3: Expect match
+    
+    if ! get_webpage "$1" "$2"; then
+        return $?
+    fi
+
+    debug "Expecting: $3"
+
+    if [[ ${webpage_output} != "$3" ]]; then
+        error "Checking '$1' expected '$3' got '${webpage_return}'"
         debug "Returning 1 from check_webpage()"
         return 1
     fi
@@ -501,17 +511,15 @@ check_result() {
 }
 
 
-check_linux_vfio() {
+get_linux_vfio_kernel_version() {
     #
-    # Check linux-vfio kernel version (this will change when the linux-vfio is updated)
+    # Get linux-vfio kernel version (this will change when the linux-vfio is updated)
     #
-    if ! source ${script_dir}/src/kernels/linux-vfio.sh; then
-        echo "!! ERROR !! -- Could not load ${script_dir}/src/kernels/linux-vfio.sh!"
-        exit 155
+    msg "Checking linux-vfio download page for the latest linux kernel version..."
+    if ! get_webpage "https://aur.archlinux.org/packages/linux-vfio" "(?<=linux-vfio )[\d\.-]+"; then
+        exit 1
     fi
-    msg "Checking linux-vfio download page for linux kernel version changes..."
-    check_webpage "https://aur.archlinux.org/packages/linux-vfio" "(?<=linux-vfio )[\d\.]+" "${kernel_version::-2}"
-    check_result "linux-vfio kernel version" "linux-vfio" "$?"
+    latest_kernel_version=${webpage_output}
 }
 
 
@@ -529,58 +537,50 @@ check_archiso() {
 }
 
 
-check_linux_hardened_kernel() {
+get_linux_hardened_kernel_version() {
+    #
+    # Get x86_64 linux-hardened kernel version
+    #
+    msg "Checking the online package database for the latest x86_64 linux-hardened kernel version..."
+    if ! get_webpage "https://www.archlinux.org/packages/extra/x86_64/linux-hardened/" "(?<=<h2>linux-hardened )[\d\w\.-]+(?=</h2>)"; then
+        exit 1
+    fi
+    latest_kernel_version=${webpage_output}
+}
+
+get_linux_zen_kernel_version() {
     #
     # Check x86_64 linux-hardened kernel version
     #
-    if ! source ${script_dir}/src/kernels/linux-hardened.sh; then
-        echo "!! ERROR !! -- Could not load ${script_dir}/src/kernels/linux-hardened.sh!"
-        exit 155
+    msg "Checking the online package database for the latest x86_64 linux-zen kernel version..."
+    if ! get_webpage "https://www.archlinux.org/packages/extra/x86_64/linux-zen/" "(?<=<h2>linux-zen )[\d\w\.-]+(?=</h2>)"; then
+        exit 1
     fi
-    msg "Checking the online package database for x86_64 linux-hardened kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/extra/x86_64/linux-hardened/" "(?<=<h2>linux-hardened )[\d\w\.-]+(?=</h2>)" "${kernel_version}"
-    check_result "x86_64 linux-hardened kernel package" "linux-hardened x86_64" "$?"
-}
-
-check_linux_zen_kernel() {
-    #
-    # Check x86_64 linux-hardened kernel version
-    #
-    if ! source ${script_dir}/src/kernels/linux-zen.sh; then
-        echo "!! ERROR !! -- Could not load ${script_dir}/src/kernels/linux-zen.sh!"
-        exit 155
-    fi
-    msg "Checking the online package database for x86_64 linux-zen kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/extra/x86_64/linux-zen/" "(?<=<h2>linux-zen )[\d\w\.-]+(?=</h2>)" "${kernel_version}"
-    check_result "x86_64 linux-zen kernel package" "linux-zen x86_64" "$?"
+    latest_kernel_version=${webpage_output}
 }
 
 
-check_linux_kernel() {
+get_linux_kernel_version() {
     #
     # Check x86_64 linux kernel version
     #
-    if ! source ${script_dir}/src/kernels/linux.sh; then
-        echo "!! ERROR !! -- Could not load ${script_dir}/src/kernels/linux.sh!"
-        exit 155
+    msg "Checking the online package database for the latest x86_64 linux kernel version..."
+    if ! get_webpage "https://www.archlinux.org/packages/core/x86_64/linux/" "(?<=<h2>linux )[\d\.-]+(?=</h2>)"; then
+        exit 1
     fi
-    msg "Checking the online package database for x86_64 linux kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/core/x86_64/linux/" "(?<=<h2>linux )[\d\.-]+(?=</h2>)" "${kernel_version}"
-    check_result "x86_64 linux kernel package" "linux x86_64" "$?"
+    latest_kernel_version=${webpage_output}
 }
 
 
-check_linux_lts_kernel() {
+get_linux_lts_kernel_version() {
     #
     # Check x86_64 linux-lts kernel version
     #
-    if ! source ${script_dir}/src/kernels/linux-lts.sh; then
-        echo "!! ERROR !! -- Could not load ${script_dir}/src/kernels/linux-lts.sh!"
-        exit 155
+    msg "Checking the online package database for the latest x86_64 linux-lts kernel version..."
+    if ! get_webpage "https://www.archlinux.org/packages/core/x86_64/linux-lts/" "(?<=<h2>linux-lts )[\d\.-]+(?=</h2>)"; then
+        exit 1
     fi
-    msg "Checking the online package database for x86_64 linux-lts kernel version changes..."
-    check_webpage "https://www.archlinux.org/packages/core/x86_64/linux-lts/" "(?<=<h2>linux-lts )[\d\.-]+(?=</h2>)" "${kernel_version}"
-    check_result "x86_64 linux-lts kernel package" "linux-lts x86_64" "$?"
+    latest_kernel_version=${webpage_output}
 }
 
 

--- a/push.sh
+++ b/push.sh
@@ -106,7 +106,7 @@ push_packages() {
         local cmd="cd \"${script_dir}/packages/${kernel_name}/${pkg}\" && "
         
         if [[ ${push} -eq 1 ]]; then
-            
+
             if [[ ! -z ${kernel_version_full} ]]; then
                 vers=$(kernel_version_full_no_hyphen ${kernel_version_full})-${zfs_pkgrel}
             elif [[ ! -z ${zfs_pkgver} ]]; then
@@ -114,7 +114,7 @@ push_packages() {
             else
                 vers="latest git commit"
             fi
-            
+
             cmd+="git --no-pager diff && echo && echo && git checkout master && git add . && "
             cmd+="git commit -m 'Semi-automated update for $vers'; git push"
         else
@@ -131,7 +131,7 @@ push_repo() {
     elif [[ ${push_repo} -ne 1 ]]; then
         return
     fi
-    run_cmd "rsync -vrtlh --delete-before ${repo_basepath}/${repo_basename} ${package_backup_dir} webfaction:/home/jalvarez/webapps/default/ ${dry}"
+    run_cmd "rsync -vrtlh --delete-before ${repo_basepath}/${repo_basename} ${package_backup_dir} ${remote_login}:${repo_remote_basepath}/ ${dry}"
     run_cmd_check 1 "Could not push packages to webfaction!"
 }
 

--- a/push.sh
+++ b/push.sh
@@ -107,16 +107,19 @@ push_packages() {
         
         if [[ ${push} -eq 1 ]]; then
 
+            vers=""
             if [[ ! -z ${kernel_version_full} ]]; then
-                vers=$(kernel_version_full_no_hyphen ${kernel_version_full})-${zfs_pkgrel}
-            elif [[ ! -z ${zfs_pkgver} ]]; then
-                vers=$zfs_pkgver
+                vers="kernel ${kernel_version_full} + "
+            fi
+
+            if [[ ! -z ${zfs_pkgver} ]]; then
+                vers+="zfs ${zol_version}"
             else
-                vers="latest git commit"
+                vers+="latest git commit"
             fi
 
             cmd+="git --no-pager diff && echo && echo && git checkout master && git add . && "
-            cmd+="git commit -m 'Semi-automated update for $vers'; git push"
+            cmd+="git commit -m 'Automated update for $vers'; git push"
         else
             cmd+="git --no-pager diff"
         fi

--- a/push.sh
+++ b/push.sh
@@ -131,8 +131,8 @@ push_repo() {
     elif [[ ${push_repo} -ne 1 ]]; then
         return
     fi
-    run_cmd "rsync -vrtlh --delete-before ${repo_basepath}/${repo_basename} ${package_backup_dir} ${remote_login}:${repo_remote_basepath}/ ${dry}"
-    run_cmd_check 1 "Could not push packages to webfaction!"
+    run_cmd "rsync -vrtlh --delete-before ${repo_basepath}/${repo_basename} ${repo_basepath}/archive_${repo_basename} ${remote_login}:${repo_remote_basepath}/ ${dry}"
+    run_cmd_check 1 "Could not push packages to remote repo!"
 }
 
 

--- a/push.sh
+++ b/push.sh
@@ -131,7 +131,7 @@ push_repo() {
     elif [[ ${push_repo} -ne 1 ]]; then
         return
     fi
-    run_cmd "rsync -vrtlh --delete-before ${repo_basepath}/${repo_name} ${package_backup_dir} webfaction:/home/jalvarez/webapps/default/ ${dry}"
+    run_cmd "rsync -vrtlh --delete-before ${repo_basepath}/${repo_basename} ${package_backup_dir} webfaction:/home/jalvarez/webapps/default/ ${dry}"
     run_cmd_check 1 "Could not push packages to webfaction!"
 }
 

--- a/repo.sh
+++ b/repo.sh
@@ -35,6 +35,7 @@ usage() {
     echo "    -n:           Dryrun; Output commands, but don't do anything."
     echo "    -d:           Show debug info."
     echo "    -s:           Sign packages only."
+    echo "    -p:           Do not sync from remote repo."
     echo
     echo "Modes:"
     echo
@@ -84,6 +85,8 @@ for (( a = 0; a < $#; a++ )); do
         repo_name="clean-chroot-manager"
     elif [[ ${args[$a]} == "-s" ]]; then
         sign_packages=1
+    elif [[ ${args[$a]} == "-p" ]]; then
+        no_pull_remote=1
     elif [[ ${args[$a]} == "-n" ]]; then
         dry_run=1
     elif [[ ${args[$a]} == "-d" ]]; then
@@ -402,10 +405,10 @@ fi
 debug "repo_name: ${repo_name}"
 debug "repo_target: ${repo_target}"
 
-if [[ ${pull_remote_repo} -eq 1 ]]; then
+if [[ ${pull_remote_repo} -eq 1 ]] && [[ ${no_pull_remote} -ne 1 ]]; then
     pull_repo
 fi
-if [[ ${pull_remote_testing_repo} -eq 1 ]]; then
+if [[ ${pull_remote_testing_repo} -eq 1 ]] && [[ ${no_pull_remote} -ne 1 ]]; then
     pull_testing_repo
 fi
 

--- a/repo.sh
+++ b/repo.sh
@@ -73,9 +73,9 @@ fi
 
 for (( a = 0; a < $#; a++ )); do
     if [[ ${args[$a]} == "azfs" ]]; then
-        repo_name="archzfs"
+        repo_name=${repo_basename}
     elif [[ ${args[$a]} == "test" ]]; then
-        repo_name="archzfs-testing"
+        repo_name="${repo_basename}-testing"
     elif [[ ${args[$a]} =~ repo=(.*) ]]; then
         repo_name=${BASH_REMATCH[1]}
     elif [[ ${args[$a]} == "ccm" ]]; then

--- a/repo.sh
+++ b/repo.sh
@@ -96,7 +96,7 @@ for (( a = 0; a < $#; a++ )); do
     fi
 done
 
-package_backup_dir="${repo_basepath}/archive_${repo_basename}"
+package_backup_dir="${repo_basepath}/archive_${repo_name}"
 
 
 if [[ $# -lt 1 ]]; then

--- a/repo.sh
+++ b/repo.sh
@@ -348,7 +348,12 @@ sign_packages() {
         if [[ ! -f "${pkgp}.sig" ]]; then
             msg2 "Signing ${pkgp}"
             # GPG_TTY prevents "gpg: signing failed: Inappropriate ioctl for device"
-            run_cmd_no_output "GPG_TTY=$(tty) gpg --batch --yes --detach-sign --use-agent -u ${gpg_sign_key} \"${script_dir}/${pkgp}\""
+            if [[ "$(tty)" == "not a tty" ]]; then
+                tty=""
+            else
+                tty="GPG_TTY=$(tty) "
+            fi
+            run_cmd_no_output "${tty}gpg --batch --yes --detach-sign --use-agent -u ${gpg_sign_key} \"${script_dir}/${pkgp}\""
             if [[ ${run_cmd_return} -ne 0 ]]; then
                 exit 1
             fi

--- a/scraper.sh
+++ b/scraper.sh
@@ -77,12 +77,7 @@ debug_print_default_vars
 export script_dir mode kernel_name
 
 
-check_linux_zen_kernel
-check_linux_hardened_kernel
-check_linux_kernel
-check_linux_lts_kernel
 check_zol_version
-check_linux_vfio
 check_archiso
 
 

--- a/src/kernels/linux-hardened.sh
+++ b/src/kernels/linux-hardened.sh
@@ -3,13 +3,11 @@ mode_name="hardened"
 package_base="linux-hardened"
 mode_desc="Select and use the packages for the linux-hardened kernel"
 
-# Kernel versions for hardened packages
+# pkgrel for hardened packages
 pkgrel="1"
-kernel_version="4.17.3.a-1"
 
-# Kernel version for GIT packages
+# pkgrel for GIT packages
 pkgrel_git="${pkgrel}"
-kernel_version_git="${kernel_version}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -35,6 +33,9 @@ header="\
 #"
 
 update_linux_hardened_pkgbuilds() {
+    get_linux_hardened_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("spl-linux-hardened" "zfs-linux-hardened")
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
@@ -63,8 +64,10 @@ update_linux_hardened_pkgbuilds() {
 }
 
 update_linux_hardened_git_pkgbuilds() {
+    get_linux_hardened_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("zfs-linux-hardened-git")
-    kernel_version=${kernel_version_git}
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
     kernel_version_major=${kernel_version%-*}

--- a/src/kernels/linux-lts.sh
+++ b/src/kernels/linux-lts.sh
@@ -3,13 +3,11 @@ mode_name="lts"
 package_base="linux-lts"
 mode_desc="Select and use the packages for the linux-lts kernel"
 
-# Kernel versions for LTS packages
+# pkgrel for LTS packages
 pkgrel="1"
-kernel_version="4.14.52-1"
 
-# Kernel version for GIT packages
+# pkgrel for GIT packages
 pkgrel_git="${pkgrel}"
-kernel_version_git="${kernel_version}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -35,6 +33,9 @@ header="\
 #"
 
 update_linux_lts_pkgbuilds() {
+    get_linux_lts_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("spl-linux-lts" "zfs-linux-lts")
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
@@ -64,8 +65,10 @@ update_linux_lts_pkgbuilds() {
 }
 
 update_linux_lts_git_pkgbuilds() {
+    get_linux_lts_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("zfs-linux-lts-git")
-    kernel_version=${kernel_version_git}
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
     kernel_version_major=${kernel_version%-*}

--- a/src/kernels/linux-vfio.sh
+++ b/src/kernels/linux-vfio.sh
@@ -3,13 +3,11 @@ mode_name="vfio"
 package_base="linux-vfio"
 mode_desc="Select and use the packages for the linux-vfio kernel"
 
-# Kernel versions for default ZFS packages
+# pkgrel for vfio packages
 pkgrel="1"
-kernel_version="4.17.2-1"
 
-# Kernel version for GIT packages
+# pkgrel for GIT packages
 pkgrel_git="${pkgrel}"
-kernel_version_git="${kernel_version}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -34,6 +32,9 @@ header="\
 #"
 
 update_linux_pkgbuilds() {
+    get_linux_vfio_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("spl-linux-vfio" "zfs-linux-vfio")
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
@@ -63,8 +64,10 @@ update_linux_pkgbuilds() {
 }
 
 update_linux_git_pkgbuilds() {
+    get_linux_vfio_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("zfs-linux-vfio-git")
-    kernel_version=${kernel_version_git}
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
     kernel_version_major=${kernel_version%-*}

--- a/src/kernels/linux-zen.sh
+++ b/src/kernels/linux-zen.sh
@@ -3,13 +3,11 @@ mode_name="zen"
 package_base="linux-zen"
 mode_desc="Select and use the packages for the linux-zen kernel"
 
-# Kernel versions for default ZFS packages
+# pkgrel for ZEN packages
 pkgrel="1"
-kernel_version="4.17.2-1"
 
-# Kernel version for GIT packages
+# pkgrel for GIT packages
 pkgrel_git="${pkgrel}"
-kernel_version_git="${kernel_version}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -34,6 +32,9 @@ header="\
 #"
 
 update_linux_pkgbuilds() {
+    get_linux_zen_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("spl-linux-zen" "zfs-linux-zen")
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
@@ -63,8 +64,10 @@ update_linux_pkgbuilds() {
 }
 
 update_linux_git_pkgbuilds() {
+    get_linux_zen_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("zfs-linux-zen-git")
-    kernel_version=${kernel_version_git}
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
     kernel_version_major=${kernel_version%-*}

--- a/src/kernels/linux.sh
+++ b/src/kernels/linux.sh
@@ -3,13 +3,11 @@ mode_name="std"
 package_base="linux"
 mode_desc="Select and use the packages for the default linux kernel"
 
-# Kernel versions for default ZFS packages
+# pkgrel for default ZFS packages
 pkgrel="1"
-kernel_version="4.17.2-1"
 
-# Kernel version for GIT packages
+# pkgrel for GIT packages
 pkgrel_git="${pkgrel}"
-kernel_version_git="${kernel_version}"
 zfs_git_commit=""
 spl_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
@@ -34,6 +32,9 @@ header="\
 #"
 
 update_linux_pkgbuilds() {
+    get_linux_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("spl-linux" "zfs-linux")
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
@@ -65,8 +66,10 @@ update_linux_pkgbuilds() {
 }
 
 update_linux_git_pkgbuilds() {
+    get_linux_kernel_version
+    kernel_version=${latest_kernel_version}
+
     pkg_list=("zfs-linux-git")
-    kernel_version=${kernel_version_git}
     kernel_version_full=$(kernel_version_full ${kernel_version})
     kernel_version_full_pkgver=$(kernel_version_full_no_hyphen ${kernel_version})
     kernel_version_major=${kernel_version%-*}

--- a/temp/.gitignore
+++ b/temp/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything except .gitingore
+*
+!.gitignore

--- a/verifier.sh
+++ b/verifier.sh
@@ -62,7 +62,7 @@ compute_remote_repo_hash() {
     # $1: The repository to compute
     # Sets remote_repo_hash
     msg2 "Computing remote $1 repository hashes..."
-    run_cmd_show_and_capture_output "ssh ${remote_login} 'cd webapps/default; sha256sum $1/*/*' | sort"
+    run_cmd_show_and_capture_output "ssh ${remote_login} 'cd ${repo_remote_basepath}/; sha256sum $1/*/*' | sort"
     if [[ ${run_cmd_return} != 0 ]]; then
         error "Could not run remote hash!"
         exit 1


### PR DESCRIPTION
This pull requests contains some commits that will be useful for automatic deployment, including the automatic kernel version increase when running `build.sh update`.

This does break `scraper.sh` check for new kernel releases, since this functionality won't be needed anymore when https://github.com/archzfs/ci-buildbot is ready to auto deploy. Until than this pull request is WIP.