### PR TITLE
Allow multiple modes in build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -116,21 +116,19 @@ generate_package_files() {
     debug "zfs_initcpio_hook_hash: ${zfs_initcpio_hook_hash}"
 
     # Make sure our target directory exists
-    if [[ ! -z ${zfs_utils_pkgbuild_path} ]]; then
+    if [[ "${kernel_name}" == "common" ]] || [[ "${kernel_name}" == "common-git" ]]; then
         run_cmd_no_output "[[ -d "${spl_utils_pkgbuild_path}" ]] || mkdir -p ${spl_utils_pkgbuild_path}"
         run_cmd_no_output "[[ -d "${zfs_utils_pkgbuild_path}" ]] || mkdir -p ${zfs_utils_pkgbuild_path}"
-    fi
-    if [[ ! -z ${zfs_pkgbuild_path} ]]; then
+    elif [[ "${kernel_name}" == "dkms" ]]; then
+        run_cmd_no_output "[[ -d "${spl_dkms_pkgbuild_path}" ]] || mkdir -p ${spl_dkms_pkgbuild_path}"
+        run_cmd_no_output "[[ -d "${zfs_dkms_pkgbuild_path}" ]] || mkdir -p ${zfs_dkms_pkgbuild_path}"
+    else
         run_cmd_no_output "[[ -d "${spl_pkgbuild_path}" ]] || mkdir -p ${spl_pkgbuild_path}"
         run_cmd_no_output "[[ -d "${zfs_pkgbuild_path}" ]] || mkdir -p ${zfs_pkgbuild_path}"
     fi
-    if [[ ! -z ${zfs_dkms_pkgbuild_path} ]]; then
-        run_cmd_no_output "[[ -d "${spl_dkms_pkgbuild_path}" ]] || mkdir -p ${spl_dkms_pkgbuild_path}"
-        run_cmd_no_output "[[ -d "${zfs_dkms_pkgbuild_path}" ]] || mkdir -p ${zfs_dkms_pkgbuild_path}"
-    fi
 
     # Finally, generate the update packages ...
-    if [[ ! -z ${zfs_utils_pkgbuild_path} ]]; then
+    if [[ "${kernel_name}" == "common" ]] || [[ "${kernel_name}" == "common-git" ]]; then
         msg2 "Creating spl-utils PKGBUILD"
         run_cmd_no_output "source ${script_dir}/src/spl-utils/PKGBUILD.sh"
 
@@ -153,9 +151,15 @@ generate_package_files() {
         run_cmd_no_output "cp ${script_dir}/src/zfs-utils/zfs-utils.initcpio.hook ${zfs_utils_pkgbuild_path}/zfs-utils.initcpio.hook"
         msg2 "Copying zfs-utils.initcpio.install"
         run_cmd_no_output "cp ${script_dir}/src/zfs-utils/zfs-utils.initcpio.install ${zfs_utils_pkgbuild_path}/zfs-utils.initcpio.install"
-    fi
+    elif [[ "${kernel_name}" == "dkms" ]]; then
+        msg2 "Creating spl-dkms PKGBUILD"
+        run_cmd_no_output "source ${script_dir}/src/spl-dkms/PKGBUILD.sh"
 
-    if [[ ! -z ${zfs_pkgbuild_path} ]]; then
+        msg2 "Creating zfs-dkms PKGBUILD"
+        run_cmd_no_output "source ${script_dir}/src/zfs-dkms/PKGBUILD.sh"
+        msg2 "Creating zfs.install"
+        run_cmd_no_output "source ${script_dir}/src/zfs-dkms/zfs.install.sh"
+    else
         # remove own headers from conflicts
         zfs_headers_conflicts=${zfs_headers_conflicts_all/"'${zfs_pkgname}-headers'"}
         spl_headers_conflicts=${spl_headers_conflicts_all/"'${spl_pkgname}-headers'"}
@@ -175,16 +179,6 @@ generate_package_files() {
         run_cmd_no_output "source ${script_dir}/src/zfs/zfs.install.sh"
         msg2 "Copying zfs patches (if any)"
         run_cmd_no_output "cp ${script_dir}/src/zfs/*.patch ${zfs_pkgbuild_path}/"
-    fi
-
-    if [[ ! -z ${zfs_dkms_pkgbuild_path} ]]; then
-        msg2 "Creating spl-dkms PKGBUILD"
-        run_cmd_no_output "source ${script_dir}/src/spl-dkms/PKGBUILD.sh"
-
-        msg2 "Creating zfs-dkms PKGBUILD"
-        run_cmd_no_output "source ${script_dir}/src/zfs-dkms/PKGBUILD.sh"
-        msg2 "Creating zfs.install"
-        run_cmd_no_output "source ${script_dir}/src/zfs-dkms/zfs.install.sh"
     fi
 
     msg "Update diffs ..."

--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,7 @@ usage() {
             echo -e "    ${mn}\t\t  ${md}"
         fi
     done
+    echo "    all           Select and use all available packages"
     echo
     echo "Commands:"
     echo

--- a/lib.sh
+++ b/lib.sh
@@ -561,20 +561,35 @@ check_zol_version() {
 check_mode() {
     # $1 the mode to check for
     debug "check_mode: checking '$1'"
+    
+    # add all available modes
+    if [[ "${1}" == "all" ]]; then
+        for m in "${mode_list[@]}"; do
+            mode=("$(echo ${m} | cut -f2 -d:)")
 
-    for m in "${mode_list[@]}"; do
-        debug "check_mode: on '${m}'"
-        local moden=$(echo ${m} | cut -f2 -d:)
-        # debug "moden: ${moden}"
-        if [[ "${moden}" == "$1" ]]; then
-            modes+=("$1")
+            # do not add archiso
+            if [[ "${mode}" == "iso" ]]; then
+                continue
+            fi
+
+            modes+=("${mode}")
             kernel_names+=("$(echo ${m} | cut -f1 -d:)")
-            return
-        fi
-    done
-    error "Unrecognized argument '$1'"
-    usage
-    exit 155
+        done
+    else
+        for m in "${mode_list[@]}"; do
+            debug "check_mode: on '${m}'"
+            local moden=$(echo ${m} | cut -f2 -d:)
+            # debug "moden: ${moden}"
+            if [[ "${moden}" == "$1" ]]; then
+                modes+=("$1")
+                kernel_names+=("$(echo ${m} | cut -f1 -d:)")
+                return
+            fi
+        done
+        error "Unrecognized argument '$1'"
+        usage
+        exit 155
+    fi
 }
 
 

--- a/push.sh
+++ b/push.sh
@@ -76,12 +76,12 @@ for (( a = 0; a < $#; a++ )); do
         usage
     else
         check_mode "${args[$a]}"
-        debug "have mode '${mode}'"
+        debug "have modes '${modes[*]}'"
     fi
 done
 
 
-if [[ ${mode} == "" && ${push_repo} -eq 0 ]]; then
+if [[ ${#modes[@]} -eq 0 && ${push_repo} -eq 0 ]]; then
     echo
     error "A mode must be selected!"
     usage
@@ -128,21 +128,25 @@ push_repo() {
 
 
 push_repo
-if [[ ${mode} == "" ]]; then
+if [[ ${#modes[@]} -eq 0 ]]; then
     exit
 fi
 
 
-get_kernel_update_funcs
-debug_print_default_vars
+for (( i = 0; i < ${#modes[@]}; i++ )); do
+    mode=${modes[i]}
+    kernel_name=${kernel_names[i]}
+
+    get_kernel_update_funcs
+    debug_print_default_vars
+
+    export script_dir mode kernel_name
+    source_safe "src/kernels/${kernel_name}.sh"
 
 
-export script_dir mode kernel_name
-source_safe "src/kernels/${kernel_name}.sh"
-
-
-for func in "${update_funcs[@]}"; do
-    debug "Evaluating '${func}'"
-    "${func}"
-    push_packages
+    for func in "${update_funcs[@]}"; do
+        debug "Evaluating '${func}'"
+        "${func}"
+        push_packages
+    done
 done

--- a/push.sh
+++ b/push.sh
@@ -45,6 +45,7 @@ usage() {
             echo -e "    ${mn}\t\t  ${md}"
         fi
     done
+    echo "    all           Select and use all available packages"
     echo
     echo "Example Usage:"
     echo

--- a/repo.sh
+++ b/repo.sh
@@ -45,6 +45,7 @@ usage() {
             echo -e "    ${mn}\t\t  ${md}"
         fi
     done
+    echo "    all           Select and use all available packages"
     echo
     echo "Repository target:"
     echo


### PR DESCRIPTION
Fixes https://github.com/archzfs/archzfs/issues/194

This does also add an `all` mode, to build all modes except for `archiso`.
I can't test push.sh. Should work fine though.