### PR TITLE
Use date of the latest commit as version for git packages

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -829,7 +829,7 @@ git_calc_pkgver() {
         # Get the version number past the last tag
         msg2 "Calculating PKGVER"
         cmd="cd temp/${repo} && "
-        cmd+="echo \$(git describe --long | sed -r 's/^${repo}-//;s/([^-]*-g)/r\1/;s/-/./g')"
+        cmd+='printf "%s.r%s.%s" "$(git log -n 1 --pretty=format:"%cd" --date=short | sed "s/-/./g")" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"'
 
         run_cmd_no_output_no_dry_run "${cmd}"
 

--- a/src/spl-dkms/PKGBUILD.sh
+++ b/src/spl-dkms/PKGBUILD.sh
@@ -17,7 +17,7 @@ provides=("spl")
 groups=("${archzfs_package_group}")
 conflicts=(${spl_conflicts} ${spl_conflicts_all} ${spl_headers_conflicts_all})
 ${spl_replaces}
-    
+
 build() {
     cd "${spl_workdir}"
     ./autogen.sh
@@ -42,7 +42,7 @@ package() {
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-	sed -i "/^build()/ i pkgver() { \n    cd \"${spl_workdir}\" \n    git describe --long | sed 's/^spl-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g' \n}" ${spl_dkms_pkgbuild_path}/PKGBUILD
+	sed -i "/^build()/i pkgver() { \n    cd \"${spl_workdir}\" \n\    printf \"%s.r%s.%s\" \"\$(git log -n 1 --pretty=format:'%cd' --date=short | sed 's/-/./g' )\" \"\$(git rev-list --count HEAD)\" \"\$(git rev-parse --short HEAD)\" \n}" ${spl_dkms_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${spl_dkms_pkgbuild_path}/PKGBUILD"

--- a/src/spl-utils/PKGBUILD.sh
+++ b/src/spl-utils/PKGBUILD.sh
@@ -31,7 +31,7 @@ package() {
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-	sed -i "/^build()/i pkgver() {\n    cd \"${spl_workdir}\"\n    git describe --long | sed 's/^spl-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g'\n}" ${spl_utils_pkgbuild_path}/PKGBUILD
+	sed -i "/^build()/i pkgver() {\n    cd \"${spl_workdir}\"\n    printf \"%s.r%s.%s\" \"\$(git log -n 1 --pretty=format:'%cd' --date=short | sed 's/-/./g')\" \"\$(git rev-list --count HEAD)\" \"\$(git rev-parse --short HEAD)\" \n}" ${spl_utils_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${spl_utils_pkgbuild_path}/PKGBUILD"

--- a/src/spl/PKGBUILD.sh
+++ b/src/spl/PKGBUILD.sh
@@ -55,7 +55,7 @@ package_${spl_pkgname}-headers() {
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-    sed -i "/^build()/i pkgver() {\n    cd \"${spl_workdir}\"\n    echo \$(git describe --long | sed 's/^spl-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g').${kernel_version_full_pkgver}\n}" ${spl_pkgbuild_path}/PKGBUILD
+    sed -i "/^build()/i pkgver() {\n    cd \"${spl_workdir}\"\n    printf \"%s.r%s.%s\" \"\$(git log -n 1 --pretty=format:'%cd' --date=short | sed 's/-/./g' )\" \"\$(git rev-list --count HEAD)\" \"\$(git rev-parse --short HEAD)\".${kernel_version_full_pkgver} \n}" ${spl_pkgbuild_path}/PKGBUILD
 else
     sed -i "/^build()/i prepare() {\n    cd \"${spl_workdir}\"\n    patch -Np1 -i \${srcdir}/0001-Linux-4.14-compat-vfs_read-vfs_write.patch\n}" ${spl_pkgbuild_path}/PKGBUILD
 fi

--- a/src/zfs-dkms/PKGBUILD.sh
+++ b/src/zfs-dkms/PKGBUILD.sh
@@ -2,7 +2,6 @@
 
 cat << EOF > ${zfs_dkms_pkgbuild_path}/PKGBUILD
 ${header}
-pkgbase="${zfs_pkgname}"
 pkgname="${zfs_pkgname}"
 pkgdesc="Kernel modules for the Zettabyte File System."
 pkgver=${zfs_pkgver}
@@ -46,7 +45,7 @@ package() {
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    git describe --long | sed 's/^zfs-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g'\n}" ${zfs_dkms_pkgbuild_path}/PKGBUILD
+	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    printf \"%s.r%s.%s\" \"\$(git log -n 1 --pretty=format:'%cd' --date=short | sed 's/-/./g')\" \"\$(git rev-list --count HEAD)\" \"\$(git rev-parse --short HEAD)\" \n}" ${zfs_dkms_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${zfs_dkms_pkgbuild_path}/PKGBUILD"

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -59,7 +59,7 @@ package() {
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    git describe --long | sed 's/^zfs-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g'\n}" ${zfs_utils_pkgbuild_path}/PKGBUILD
+	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    printf \"%s.r%s.%s\" \"\$(git log -n 1 --pretty=format:'%cd' --date=short | sed 's/-/./g')\" \"\$(git rev-list --count HEAD)\" \"\$(git rev-parse --short HEAD)\" \n}" ${zfs_utils_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${zfs_utils_pkgbuild_path}/PKGBUILD"

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -57,7 +57,7 @@ package_${zfs_pkgname}-headers() {
 EOF
 
 if [[ ${archzfs_package_group} =~ -git$ ]]; then
-	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    echo \$(git describe --long | sed 's/^zfs-//;s/\\\([^-]*-g\\\)/r\\\1/;s/-/./g').${kernel_version_full_pkgver}\n}" ${zfs_pkgbuild_path}/PKGBUILD
+	sed -i "/^build()/i pkgver() {\n    cd \"${zfs_workdir}\"\n    printf \"%s.r%s.%s\" \"\$(git log -n 1 --pretty=format:'%cd' --date=short | sed 's/-/./g')\" \"\$(git rev-list --count HEAD)\" \"\$(git rev-parse --short HEAD)\".${kernel_version_full_pkgver} \n}" ${zfs_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${zfs_pkgbuild_path}/PKGBUILD"


### PR DESCRIPTION
Closes https://github.com/archzfs/archzfs/issues/198

This will change versions of all git packages from something like 
`0.7.0.r200.gd4677269f.4.14.3.1-4`
 to
 `2017.11.15.r1059.gd4677269f.4.14.3.1`