### PR TITLE
Fix package permissions for '/etc/sudoers.d'

### DIFF
--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -51,6 +51,9 @@ package() {
     mkdir -p "\${pkgdir}/etc/modules-load.d"
     printf "%s\n" "zfs" > "\${pkgdir}/etc/modules-load.d/zfs.conf"
 
+    # fix permissions
+    chmod 750 \${pkgdir}/etc/sudoers.d
+
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.install "\${pkgdir}"/usr/lib/initcpio/install/zfs


### PR DESCRIPTION
Prevents this message on install / upgrade:
```
(1/1) upgrading zfs-utils-common                                                               [########################################################] 100%
warning: directory permissions differ on /etc/sudoers.d/
filesystem: 750  package: 755
```

Just a very minor change, so I didn't increase the pkrel