### PR TITLE
Do not skip sha256sum when using multiple commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,9 @@ if ! source ${script_dir}/lib.sh; then
 fi
 source_safe "${script_dir}/conf.sh"
 
+# save conf variables
+spl_src_hash_conf=${spl_src_hash}
+zfs_src_hash_conf=${zfs_src_hash}
 
 usage() {
     echo "${script_name} - A build script for archzfs"

--- a/lib.sh
+++ b/lib.sh
@@ -403,6 +403,8 @@ source_safe() {
     kernel_version=""
     zfs_pkgver=""
     spl_pkgver=""
+    spl_src_hash=${spl_src_hash_conf}
+    zfs_src_hash=${zfs_src_hash_conf}
 
     export script_dir mode kernel_name
     shopt -u extglob


### PR DESCRIPTION
The spl/zfs src hash was always set to "SKIP", even on non git packages. 