### PR TITLE
Improve predictability at boot time and close #50

### DIFF
--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -103,12 +103,17 @@ zfs_mount_handler () {
     done
 }
 
-run_hook() {
+set_flags() {
     # Force import the pools, useful if the pool has not properly been exported using 'zpool export <pool>'
     [ ! "${zfs_force}" = "" ] && ZPOOL_FORCE="-f"
 
     # Add import directory to import command flags
     [ ! "${zfs_import_dir}" = "" ] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -d ${zfs_import_dir}"
+    [ "${zfs_import_dir}" = "" ] && ZPOOL_IMPORT_FLAGS="${ZPOOL_IMPORT_FLAGS} -c /etc/zfs/zpool.cache"
+}
+
+run_hook() {
+    set_flags
 
     # Wait 15 seconds for ZFS devices to show up
     [ "${zfs_wait}" = "" ] && ZFS_WAIT="15" || ZFS_WAIT="${zfs_wait}"
@@ -132,22 +137,45 @@ run_hook() {
         auto|bootfs)
             ZFS_DATASET="bootfs"
             mount_handler="zfs_mount_handler"
+            local pool="[a-zA-Z][^ ]*"
             ;;
         *)
             ZFS_DATASET="${zfs}"
             mount_handler="zfs_mount_handler"
+            local pool="${ZFS_DATASET%%/*}"
             ;;
     esac
 
-    # Allow up to n seconds for zfs device to show up
-    for i in $(seq 1 ${ZFS_WAIT}); do
-        [ -c "/dev/zfs" ] && break
+    # Allow at least n seconds for zfs device to show up.  Especially
+    # when using zfs_import_dir instead of zpool.cache, the listing of
+    # available pools can be slow, so this loop must be top-tested to
+    # ensure we do one 'zpool import' pass after the timer has expired.
+    sleep ${ZFS_WAIT} & pid=$!
+    local break_after=0
+    while :; do
+        kill -0 $pid > /dev/null 2>&1 || break_after=1
+        if [ -c "/dev/zfs" ]; then
+            zpool import ${ZPOOL_IMPORT_FLAGS} | awk "
+                BEGIN     { pool_found=0; online=0; unavail=0 }
+                /^	${pool} .*/ { pool_found=1 }
+                /^\$/      { pool_found=0 }
+                /UNAVAIL/ { if (pool_found == 1) { unavail=1 } }
+                /ONLINE/  { if (pool_found == 1) { online=1 } }
+                END       { if (online == 1 && unavail != 1)
+                              { exit 0 }
+                            else
+                              { exit 1 }
+                          }" && break
+        fi
+        [ $break_after == 1 ] && break
         sleep 1
     done
+    kill $pid > /dev/null 2>&1
 }
 
 run_latehook () {
-    zpool import -N -a ${ZPOOL_FORCE}
+    set_flags
+    zpool import ${ZPOOL_IMPORT_FLAGS} -N -a ${ZPOOL_FORCE}
 }
 
 # vim:set ts=4 sw=4 ft=sh et:


### PR DESCRIPTION
 - fix a problem introduced ~2018-03-18 where waiting for /dev/zfs
   to appear no longer waits for all, or enough, of the vdevs.

 - always use /etc/zfs/zpool.cache if zfs_import_dir is not specified,
   which generally makes imports faster.

 - obey command line arguments in the late hook.

 - mitigate issue #50:  when zfs_import_dir is not specified, do
   not, in the late hook, import any pool not mentioned in
   /etc/zfs/zpool.cache as of mkinitcpio time.