### PR TITLE
Adding remote root filesystem decryption initcpio hook

### DIFF
--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -64,6 +64,7 @@ package() {
     # Install the support files
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.hook "\${pkgdir}"/usr/lib/initcpio/hooks/zfs
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.install "\${pkgdir}"/usr/lib/initcpio/install/zfs
+    install -D -m644 "\${srcdir}"/zfs-utils.initcpio.zfsencryptssh.install "\${pkgdir}"/usr/lib/initcpio/install/zfsencryptssh
     install -D -m644 "\${srcdir}"/zfs-utils.bash-completion-r1 "\${pkgdir}"/usr/share/bash-completion/completions/zfs
 }
 EOF

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -40,8 +40,9 @@ zfs_decrypt_fs() {
     # get the encryption root
     encryptionroot=$(zfs get -H -o value encryptionroot "${dataset}")
 
-    # loop until we get the correct password
-    while ! eval zfs load-key "${encryptionroot}"; do
+    # loop until we get the correct password or key is unlocked by another vector (SSH for instance)
+    while [ "$(zfs get -H -o value keystatus "${encryptionroot}")" != "available" ] &&
+      ! eval zfs load-key "${encryptionroot}"; do
         sleep 2
     done
 }

--- a/src/zfs-utils/zfs-utils.initcpio.zfsencryptssh.install
+++ b/src/zfs-utils/zfs-utils.initcpio.zfsencryptssh.install
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+make_etc_passwd() {
+    echo 'root:x:0:0:root:/root:/bin/bash' > "${BUILDROOT}"/etc/passwd
+    echo '/bin/bash' > "${BUILDROOT}"/etc/shells
+}
+
+make_profile() {
+    profile_file='# get bootfs (dataset must have bootfs flag set to work)
+dataset=$(zpool list -H -o bootfs)
+# source zfs hook functions
+. /hooks/zfs
+# decrypt bootfs
+zfs_decrypt_fs $dataset
+# kill pending decryption attempt to allow the boot process to continue
+killall zfs
+# exit properly
+exit'
+    printf '%s' "$profile_file" > "${BUILDROOT}"/root/.profile
+}
+
+build ()
+{
+    make_etc_passwd
+    make_profile
+}
+
+help ()
+{
+    cat<<HELPEOF
+This hook is meant to be used in conjunction with mkinitcpio-dropbear, 
+mkinitcpio-netconf and/ormkinitcpio-ppp. This will provide a way to unlock 
+your encrypted ZFS root filesystem remotely.
+HELPEOF
+}
+
+# vim: set ts=4 sw=4 ft=sh et:


### PR DESCRIPTION
Here's a patch to allow the init process to continue if an encrypted root partition is unlocked via SSH on boot. 
Once the unlock via SSH is done, the "zfs load-key" process needs to be killed. Then, the condition [ "$(zfs get -H -o value keystatus "${encryptionroot}")" != "available" ] becomes false and breaks the loop.
I'll develop an external initcpio hook to implement remote unlocking via this repo: https://github.com/grazzolini/mkinitcpio-utils as it already implements a similar system for LUKS.
