### PR TITLE
Add Linux 5.5 compat patch

### DIFF
--- a/src/kernels/dkms.sh
+++ b/src/kernels/dkms.sh
@@ -3,7 +3,7 @@ mode_name="dkms"
 mode_desc="Select and use the dkms packages"
 
 # version
-pkgrel="1"
+pkgrel="2"
 
 # Version for GIT packages
 pkgrel_git="1"

--- a/src/zfs-dkms/PKGBUILD.sh
+++ b/src/zfs-dkms/PKGBUILD.sh
@@ -10,8 +10,10 @@ pkgrel=${zfs_pkgrel}
 makedepends=(${zfs_makedepends})
 arch=("x86_64")
 url="https://zfsonlinux.org/"
-source=("${zfs_src_target}")
-sha256sums=("${zfs_src_hash}")
+source=("${zfs_src_target}"
+        "linux-5.5-compat-blkg_tryget.patch")
+sha256sums=("${zfs_src_hash}"
+            "daae58460243c45c2c7505b1d88dcb299ea7d92bcf3f41d2d30bc213000bb1da")
 license=("CDDL")
 depends=("${zfs_utils_pkgname}" "lsb-release" "dkms")
 provides=("zfs" "zfs-headers" "spl" "spl-headers")
@@ -37,5 +39,9 @@ package() {
 
 
 EOF
+
+if [[ ! ${archzfs_package_group} =~ -git$ ]] && [[ ! ${archzfs_package_group} =~ -rc$ ]]; then
+    sed -E -i "/^build()/i prepare() {\n    cd \"${zfs_workdir}\"\n    patch -Np1 -i \${srcdir}/linux-5.5-compat-blkg_tryget.patch\n}" ${zfs_dkms_pkgbuild_path}/PKGBUILD
+fi
 
 pkgbuild_cleanup "${zfs_dkms_pkgbuild_path}/PKGBUILD"

--- a/src/zfs-dkms/linux-5.5-compat-blkg_tryget.patch
+++ b/src/zfs-dkms/linux-5.5-compat-blkg_tryget.patch
@@ -1,0 +1,136 @@
+From 2fcab8795c7c493845bfa277d44bc443802000b8 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Fri, 28 Feb 2020 08:58:39 -0800
+Subject: [PATCH] Linux 5.5 compat: blkg_tryget()
+
+Commit https://github.com/torvalds/linux/commit/9e8d42a0f accidentally
+converted the static inline function blkg_tryget() to GPL-only for
+kernels built with CONFIG_PREEMPT_RCU=y and CONFIG_BLK_CGROUP=y.
+
+Resolve the build issue by providing our own equivalent functionality
+when needed which uses rcu_read_lock_sched() internally as before.
+
+Reviewed-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #9745
+Closes #10072
+---
+ config/kernel-blkg-tryget.m4 | 37 ++++++++++++++++++++++++++++++++++++
+ config/kernel.m4             |  2 ++
+ module/zfs/vdev_disk.c       | 32 ++++++++++++++++++++++++++++++-
+ 3 files changed, 70 insertions(+), 1 deletion(-)
+ create mode 100644 config/kernel-blkg-tryget.m4
+
+diff --git a/config/kernel-blkg-tryget.m4 b/config/kernel-blkg-tryget.m4
+new file mode 100644
+index 00000000000..fb831ca3b3e
+--- /dev/null
++++ b/config/kernel-blkg-tryget.m4
+@@ -0,0 +1,37 @@
++dnl #
++dnl # Linux 5.5 API,
++dnl #
++dnl # The Linux 5.5 kernel updated percpu_ref_tryget() which is inlined by
++dnl # blkg_tryget() to use rcu_read_lock() instead of rcu_read_lock_sched().
++dnl # As a side effect the function was converted to GPL-only.
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKG_TRYGET], [
++	ZFS_LINUX_TEST_SRC([blkg_tryget], [
++		#include <linux/blk-cgroup.h>
++		#include <linux/bio.h>
++		#include <linux/fs.h>
++	],[
++		struct blkcg_gq blkg __attribute__ ((unused));
++		bool rc __attribute__ ((unused));
++		rc = blkg_tryget(&blkg);
++	], [], [$ZFS_META_LICENSE])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_BLKG_TRYGET], [
++	AC_MSG_CHECKING([whether blkg_tryget() is available])
++	ZFS_LINUX_TEST_RESULT([blkg_tryget], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_BLKG_TRYGET, 1, [blkg_tryget() is available])
++
++		AC_MSG_CHECKING([whether blkg_tryget() is GPL-only])
++		ZFS_LINUX_TEST_RESULT([blkg_tryget_license], [
++			AC_MSG_RESULT(no)
++		],[
++			AC_MSG_RESULT(yes)
++			AC_DEFINE(HAVE_BLKG_TRYGET_GPL_ONLY, 1,
++			    [blkg_tryget() GPL-only])
++		])
++	],[
++		AC_MSG_RESULT(no)
++	])
++])
+diff --git a/config/kernel.m4 b/config/kernel.m4
+index dce619729d4..bea6f9b1bbf 100644
+--- a/config/kernel.m4
++++ b/config/kernel.m4
+@@ -70,6 +70,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
+ 	ZFS_AC_KERNEL_SRC_BIO_BI_STATUS
+ 	ZFS_AC_KERNEL_SRC_BIO_RW_BARRIER
+ 	ZFS_AC_KERNEL_SRC_BIO_RW_DISCARD
++	ZFS_AC_KERNEL_SRC_BLKG_TRYGET
+ 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_BDI
+ 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_DISCARD
+ 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_SECURE_ERASE
+@@ -186,6 +187,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
+ 	ZFS_AC_KERNEL_BIO_BI_STATUS
+ 	ZFS_AC_KERNEL_BIO_RW_BARRIER
+ 	ZFS_AC_KERNEL_BIO_RW_DISCARD
++	ZFS_AC_KERNEL_BLKG_TRYGET
+ 	ZFS_AC_KERNEL_BLK_QUEUE_BDI
+ 	ZFS_AC_KERNEL_BLK_QUEUE_DISCARD
+ 	ZFS_AC_KERNEL_BLK_QUEUE_SECURE_ERASE
+diff --git a/module/zfs/vdev_disk.c b/module/zfs/vdev_disk.c
+index 661f0f1b727..8544bb8ffb6 100644
+--- a/module/zfs/vdev_disk.c
++++ b/module/zfs/vdev_disk.c
+@@ -473,6 +473,36 @@ vdev_submit_bio_impl(struct bio *bio)
+ 
+ #ifdef HAVE_BIO_SET_DEV
+ #if defined(CONFIG_BLK_CGROUP) && defined(HAVE_BIO_SET_DEV_GPL_ONLY)
++/*
++ * The Linux 5.5 kernel updated percpu_ref_tryget() which is inlined by
++ * blkg_tryget() to use rcu_read_lock() instead of rcu_read_lock_sched().
++ * As a side effect the function was converted to GPL-only.  Define our
++ * own version when needed which uses rcu_read_lock_sched().
++ */
++#if defined(HAVE_BLKG_TRYGET_GPL_ONLY)
++static inline bool
++vdev_blkg_tryget(struct blkcg_gq *blkg)
++{
++	struct percpu_ref *ref = &blkg->refcnt;
++	unsigned long __percpu *count;
++	bool rc;
++
++	rcu_read_lock_sched();
++
++	if (__ref_is_percpu(ref, &count)) {
++		this_cpu_inc(*count);
++		rc = true;
++	} else {
++		rc = atomic_long_inc_not_zero(&ref->count);
++	}
++
++	rcu_read_unlock_sched();
++
++	return (rc);
++}
++#elif defined(HAVE_BLKG_TRYGET)
++#define	vdev_blkg_tryget(bg)	blkg_tryget(bg)
++#endif
+ /*
+  * The Linux 5.0 kernel updated the bio_set_dev() macro so it calls the
+  * GPL-only bio_associate_blkg() symbol thus inadvertently converting
+@@ -487,7 +517,7 @@ vdev_bio_associate_blkg(struct bio *bio)
+ 	ASSERT3P(q, !=, NULL);
+ 	ASSERT3P(bio->bi_blkg, ==, NULL);
+ 
+-	if (q->root_blkg && blkg_tryget(q->root_blkg))
++	if (q->root_blkg && vdev_blkg_tryget(q->root_blkg))
+ 		bio->bi_blkg = q->root_blkg;
+ }
+ #define	bio_associate_blkg vdev_bio_associate_blkg

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -66,7 +66,7 @@ package_${zfs_pkgname}-headers() {
 EOF
 
 if [[ ! ${archzfs_package_group} =~ -git$ ]] && [[ ! ${archzfs_package_group} =~ -rc$ ]]; then
-    sed -E -i "/^build()/i prepare() {\n    cd \"${zfs_workdir}\"\n    patch -Np1 -i \${srcdir}/linux-5.5-compat-blkg_tryget.patch\n}" ${zfs_dkms_pkgbuild_path}/PKGBUILD
+    sed -E -i "/^build()/i prepare() {\n    cd \"${zfs_workdir}\"\n    patch -Np1 -i \${srcdir}/linux-5.5-compat-blkg_tryget.patch\n}" ${zfs_pkgbuild_path}/PKGBUILD
 fi
 
 pkgbuild_cleanup "${zfs_pkgbuild_path}/PKGBUILD"

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -15,8 +15,10 @@ pkgrel=${zfs_pkgrel}
 makedepends=(${linux_headers_depends} ${zfs_makedepends})
 arch=("x86_64")
 url="https://zfsonlinux.org/"
-source=("${zfs_src_target}")
-sha256sums=("${zfs_src_hash}")
+source=("${zfs_src_target}"
+        "linux-5.5-compat-blkg_tryget.patch")
+sha256sums=("${zfs_src_hash}"
+            "daae58460243c45c2c7505b1d88dcb299ea7d92bcf3f41d2d30bc213000bb1da")
 license=("CDDL")
 depends=("kmod" "${zfs_utils_pkgname}" ${linux_depends})
 
@@ -62,5 +64,9 @@ package_${zfs_pkgname}-headers() {
 }
 
 EOF
+
+if [[ ! ${archzfs_package_group} =~ -git$ ]] && [[ ! ${archzfs_package_group} =~ -rc$ ]]; then
+    sed -E -i "/^build()/i prepare() {\n    cd \"${zfs_workdir}\"\n    patch -Np1 -i \${srcdir}/linux-5.5-compat-blkg_tryget.patch\n}" ${zfs_dkms_pkgbuild_path}/PKGBUILD
+fi
 
 pkgbuild_cleanup "${zfs_pkgbuild_path}/PKGBUILD"

--- a/src/zfs/linux-5.5-compat-blkg_tryget.patch
+++ b/src/zfs/linux-5.5-compat-blkg_tryget.patch
@@ -1,0 +1,136 @@
+From 2fcab8795c7c493845bfa277d44bc443802000b8 Mon Sep 17 00:00:00 2001
+From: Brian Behlendorf <behlendorf1@llnl.gov>
+Date: Fri, 28 Feb 2020 08:58:39 -0800
+Subject: [PATCH] Linux 5.5 compat: blkg_tryget()
+
+Commit https://github.com/torvalds/linux/commit/9e8d42a0f accidentally
+converted the static inline function blkg_tryget() to GPL-only for
+kernels built with CONFIG_PREEMPT_RCU=y and CONFIG_BLK_CGROUP=y.
+
+Resolve the build issue by providing our own equivalent functionality
+when needed which uses rcu_read_lock_sched() internally as before.
+
+Reviewed-by: Tony Hutter <hutter2@llnl.gov>
+Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
+Closes #9745
+Closes #10072
+---
+ config/kernel-blkg-tryget.m4 | 37 ++++++++++++++++++++++++++++++++++++
+ config/kernel.m4             |  2 ++
+ module/zfs/vdev_disk.c       | 32 ++++++++++++++++++++++++++++++-
+ 3 files changed, 70 insertions(+), 1 deletion(-)
+ create mode 100644 config/kernel-blkg-tryget.m4
+
+diff --git a/config/kernel-blkg-tryget.m4 b/config/kernel-blkg-tryget.m4
+new file mode 100644
+index 00000000000..fb831ca3b3e
+--- /dev/null
++++ b/config/kernel-blkg-tryget.m4
+@@ -0,0 +1,37 @@
++dnl #
++dnl # Linux 5.5 API,
++dnl #
++dnl # The Linux 5.5 kernel updated percpu_ref_tryget() which is inlined by
++dnl # blkg_tryget() to use rcu_read_lock() instead of rcu_read_lock_sched().
++dnl # As a side effect the function was converted to GPL-only.
++dnl #
++AC_DEFUN([ZFS_AC_KERNEL_SRC_BLKG_TRYGET], [
++	ZFS_LINUX_TEST_SRC([blkg_tryget], [
++		#include <linux/blk-cgroup.h>
++		#include <linux/bio.h>
++		#include <linux/fs.h>
++	],[
++		struct blkcg_gq blkg __attribute__ ((unused));
++		bool rc __attribute__ ((unused));
++		rc = blkg_tryget(&blkg);
++	], [], [$ZFS_META_LICENSE])
++])
++
++AC_DEFUN([ZFS_AC_KERNEL_BLKG_TRYGET], [
++	AC_MSG_CHECKING([whether blkg_tryget() is available])
++	ZFS_LINUX_TEST_RESULT([blkg_tryget], [
++		AC_MSG_RESULT(yes)
++		AC_DEFINE(HAVE_BLKG_TRYGET, 1, [blkg_tryget() is available])
++
++		AC_MSG_CHECKING([whether blkg_tryget() is GPL-only])
++		ZFS_LINUX_TEST_RESULT([blkg_tryget_license], [
++			AC_MSG_RESULT(no)
++		],[
++			AC_MSG_RESULT(yes)
++			AC_DEFINE(HAVE_BLKG_TRYGET_GPL_ONLY, 1,
++			    [blkg_tryget() GPL-only])
++		])
++	],[
++		AC_MSG_RESULT(no)
++	])
++])
+diff --git a/config/kernel.m4 b/config/kernel.m4
+index dce619729d4..bea6f9b1bbf 100644
+--- a/config/kernel.m4
++++ b/config/kernel.m4
+@@ -70,6 +70,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_SRC], [
+ 	ZFS_AC_KERNEL_SRC_BIO_BI_STATUS
+ 	ZFS_AC_KERNEL_SRC_BIO_RW_BARRIER
+ 	ZFS_AC_KERNEL_SRC_BIO_RW_DISCARD
++	ZFS_AC_KERNEL_SRC_BLKG_TRYGET
+ 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_BDI
+ 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_DISCARD
+ 	ZFS_AC_KERNEL_SRC_BLK_QUEUE_SECURE_ERASE
+@@ -186,6 +187,7 @@ AC_DEFUN([ZFS_AC_KERNEL_TEST_RESULT], [
+ 	ZFS_AC_KERNEL_BIO_BI_STATUS
+ 	ZFS_AC_KERNEL_BIO_RW_BARRIER
+ 	ZFS_AC_KERNEL_BIO_RW_DISCARD
++	ZFS_AC_KERNEL_BLKG_TRYGET
+ 	ZFS_AC_KERNEL_BLK_QUEUE_BDI
+ 	ZFS_AC_KERNEL_BLK_QUEUE_DISCARD
+ 	ZFS_AC_KERNEL_BLK_QUEUE_SECURE_ERASE
+diff --git a/module/zfs/vdev_disk.c b/module/zfs/vdev_disk.c
+index 661f0f1b727..8544bb8ffb6 100644
+--- a/module/zfs/vdev_disk.c
++++ b/module/zfs/vdev_disk.c
+@@ -473,6 +473,36 @@ vdev_submit_bio_impl(struct bio *bio)
+ 
+ #ifdef HAVE_BIO_SET_DEV
+ #if defined(CONFIG_BLK_CGROUP) && defined(HAVE_BIO_SET_DEV_GPL_ONLY)
++/*
++ * The Linux 5.5 kernel updated percpu_ref_tryget() which is inlined by
++ * blkg_tryget() to use rcu_read_lock() instead of rcu_read_lock_sched().
++ * As a side effect the function was converted to GPL-only.  Define our
++ * own version when needed which uses rcu_read_lock_sched().
++ */
++#if defined(HAVE_BLKG_TRYGET_GPL_ONLY)
++static inline bool
++vdev_blkg_tryget(struct blkcg_gq *blkg)
++{
++	struct percpu_ref *ref = &blkg->refcnt;
++	unsigned long __percpu *count;
++	bool rc;
++
++	rcu_read_lock_sched();
++
++	if (__ref_is_percpu(ref, &count)) {
++		this_cpu_inc(*count);
++		rc = true;
++	} else {
++		rc = atomic_long_inc_not_zero(&ref->count);
++	}
++
++	rcu_read_unlock_sched();
++
++	return (rc);
++}
++#elif defined(HAVE_BLKG_TRYGET)
++#define	vdev_blkg_tryget(bg)	blkg_tryget(bg)
++#endif
+ /*
+  * The Linux 5.0 kernel updated the bio_set_dev() macro so it calls the
+  * GPL-only bio_associate_blkg() symbol thus inadvertently converting
+@@ -487,7 +517,7 @@ vdev_bio_associate_blkg(struct bio *bio)
+ 	ASSERT3P(q, !=, NULL);
+ 	ASSERT3P(bio->bi_blkg, ==, NULL);
+ 
+-	if (q->root_blkg && blkg_tryget(q->root_blkg))
++	if (q->root_blkg && vdev_blkg_tryget(q->root_blkg))
+ 		bio->bi_blkg = q->root_blkg;
+ }
+ #define	bio_associate_blkg vdev_bio_associate_blkg


### PR DESCRIPTION
Upstream fix: https://github.com/openzfs/zfs/pull/10072

```
frebib@frebib-PC /t/t/p/d/zfs-dkms> p -U zfs-dkms-0.8.3-2-x86_64.pkg.tar.zst
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) zfs-dkms-0.8.3-2

Total Installed Size:  30.90 MiB
Net Upgrade Size:       0.02 MiB

:: Proceed with installation? [Y/n]
(1/1) checking keys in keyring                                              
(1/1) checking package integrity                                            
(1/1) loading package files                                                 
(1/1) checking for file conflicts                                           
(1/1) checking available disk space                                         
:: Running pre-transaction hooks...
(1/1) Remove DKMS modules
==> dkms remove zfs/0.8.3 -k 5.4.22-1-lts
:: Processing package changes...
(1/1) upgrading zfs-dkms                                                    
:: Running post-transaction hooks...
(1/2) Arming ConditionNeedsUpdate...
(2/2) Install DKMS modules
==> dkms install zfs/0.8.3 -k 5.4.22-1-lts
==> dkms install zfs/0.8.3 -k 5.5.6-arch1-1
```
```
==> Image generation successful
==> Building image from preset: /etc/mkinitcpio.d/linux.preset: 'default'
  -> -k /boot/vmlinuz-linux -c /etc/mkinitcpio.conf -g /boot/initramfs-linux.img
==> Starting build: 5.5.6-arch1-1
  -> Running build hook: [base]
  -> Running build hook: [udev]
  -> Running build hook: [autodetect]
  -> Running build hook: [keymap]
  -> Running build hook: [keyboard]
  -> Running build hook: [modconf]
  -> Running build hook: [block]
  -> Running build hook: [zfs]
  -> Running build hook: [filesystems]
==> Generating module dependencies
==> Creating bzip2-compressed initcpio image: /boot/initramfs-linux.img
==> Image generation successful
```