### PR TITLE
Append user information to passwd

### DIFF
--- a/src/zfs-utils/zfs-utils.initcpio.zfsencryptssh.install
+++ b/src/zfs-utils/zfs-utils.initcpio.zfsencryptssh.install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 make_etc_passwd() {
-    echo 'root:x:0:0:root:/root:/bin/zfsdecrypt_shell' > "${BUILDROOT}"/etc/passwd
+    echo 'root:x:0:0:root:/root:/bin/zfsdecrypt_shell' >> "${BUILDROOT}"/etc/passwd
     echo '/bin/zfsdecrypt_shell' > "${BUILDROOT}"/etc/shells
 }
 


### PR DESCRIPTION
make_etc_passwd() is overwriting user information `passwd` from earlier hooks.

Signed-off-by: Gavin Scurr <gavin@scurr.me>
Closes #N/A
Issue #N/A