### PR TITLE
Reminder: Fix for a pending PR

### DIFF
--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -40,7 +40,7 @@ package_${zfs_pkgname}() {
     ${zfs_replaces}
 
     cd "${zfs_workdir}"
-    make DESTDIR="\${pkgdir}" INSTALL_MOD_PATH=/usr install
+    make DESTDIR="\${pkgdir}" INSTALL_MOD_PATH="\${pkgdir}/usr" install
 
     # Remove src dir
     rm -r "\${pkgdir}"/usr/src


### PR DESCRIPTION
Hello.

Please, consider this Pull Request as a reminder for future ZFS releases. (>2.1.1)

This PR https://github.com/openzfs/zfs/pull/12577 will breaks the current PKGBUILD.

The environment INSTALL_MOD_PATH will not include DESTDIR by default anymore.
This behavior is very common in cross-compilations, where the DESTDIR and
INSTALL_MOD_PATH must be completely different paths.