### PR TITLE
Wait for udev to settle if keylocation is a local file

### DIFF
--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -58,18 +58,22 @@ zfs_decrypt_fs() {
             keyfile="${keylocation#file://}"
 
             # If file not yet exist, wait for udev to create device nodes
-            [ -r "${keyfile}"] || udevadm settle
+            if [ ! -r "${keyfile}" ]; then
+                udevadm settle
 
-            # Wait for udev up to 10 seconds
-            [ -r "${keyfile}" ] || {
-                echo "Waiting for key ${keyfile} for ${encryptionroot}..."
-                for _ in $(seq 1 20); do
-                    sleep 0.5s
-                    [ -r "${keyfile}" ] && break
-                done
-            }
+                # Wait for udev up to 10 seconds
+                if [ ! -r "${keyfile}" ]; then 
+                    echo "Waiting for key ${keyfile} for ${encryptionroot}..."
+                    for _ in $(seq 1 20); do
+                        sleep 0.5s
+                        [ -r "${keyfile}" ] && break
+                    done
+                fi
 
-            [ -r "${keyfile}" ] || echo "Key ${keyfile} for ${encryptionroot} hasn't appeared. Trying anyway."
+                if [ ! -r "${keyfile}" ]; then
+                    echo "Key ${keyfile} for ${encryptionroot} hasn't appeared. Trying anyway."
+                fi
+            fi
         fi
     fi
 

--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -44,13 +44,32 @@ zfs_decrypt_fs() {
     # Export encryption root to be used by other hooks (SSH)
     echo "${encryptionroot}" > /.encryptionroot
 
-    # If key location is a file, determine if it can by overridden by prompt
     prompt_override=""
-    if keylocation="$(zfs get -H -o value keylocation "${dataset}")"; then
+    if keylocation="$(zfs get -H -o value keylocation "${encryptionroot}")"; then
+        # If key location is a file, determine if it can by overridden by prompt
         if [ "${keylocation}" != "prompt" ]; then
-            if keyformat="$(zfs get -H -o value keyformat "${dataset}")"; then
+            if keyformat="$(zfs get -H -o value keyformat "${encryptionroot}")"; then
                 [ "${keyformat}" = "passphrase" ] && prompt_override="yes"
             fi
+        fi
+
+        # If key location is a local file, check if file exists
+        if [ "${keylocation%%://*}" = "file" ]; then
+            keyfile="${keylocation#file://}"
+
+            # If file not yet exist, wait for udev to create device nodes
+            [ -r "${keyfile}"] || udevadm settle
+
+            # Wait for udev up to 10 seconds
+            [ -r "${keyfile}" ] || {
+                echo "Waiting for key ${keyfile} for ${encryptionroot}..."
+                for _ in $(seq 1 20); do
+                    sleep 0.5s
+                    [ -r "${keyfile}" ] && break
+                done
+            }
+
+            [ -r "${keyfile}" ] || echo "Key ${keyfile} for ${encryptionroot} hasn't appeared. Trying anyway."
         fi
     fi
 

--- a/src/zfs-utils/zfs-utils.initcpio.install
+++ b/src/zfs-utils/zfs-utils.initcpio.install
@@ -22,7 +22,8 @@ build() {
         zstreamdump \
         /lib/udev/vdev_id \
         /lib/udev/zvol_id \
-        findmnt
+        findmnt \
+        udevadm
 
     map add_file \
         /lib/udev/rules.d/60-zvol.rules \


### PR DESCRIPTION
If an encrypted dataset has a file keylocation on an external device, like an USB flash drive, zfs_decrypt_fs will fail to read the file.
A solution is to wait for udev events to be handled and keylocation to appear, which has been implemented in zfs-dracut (https://github.com/openzfs/zfs/blob/3fa5266d727a0e9506dfeed0118cbe7dd3c2a18d/contrib/dracut/90zfs/zfs-load-key.sh.in#L56).
I've adopted the solution here.
Closes #426 