### PR TITLE
Add /etc/fstab to initramfs

### DIFF
--- a/src/zfs-utils/zfs-utils.initcpio.hook
+++ b/src/zfs-utils/zfs-utils.initcpio.hook
@@ -129,7 +129,7 @@ zfs_mount_handler () {
 
     local node="$1"
     local rootmnt=$(zfs get -H -o value mountpoint "${ZFS_DATASET}")
-    local tab_file="${node}/etc/fstab"
+    local tab_file="/etc/fstab"
     local zfs_datasets="$(zfs list -H -o name -t filesystem -r ${ZFS_DATASET})"
 
     # Mount the root, and any child datasets

--- a/src/zfs-utils/zfs-utils.initcpio.install
+++ b/src/zfs-utils/zfs-utils.initcpio.install
@@ -41,6 +41,7 @@ build() {
 
     [[ -f /etc/zfs/zpool.cache ]] && cp "/etc/zfs/zpool.cache" "${BUILDROOT}/etc/zfs/zpool.cache.org"
     [[ -f /etc/modprobe.d/zfs.conf ]] && add_file "/etc/modprobe.d/zfs.conf"
+    [[ -f /etc/fstab ]] && add_file "/etc/fstab"
 }
 
 help() {


### PR DESCRIPTION
I spent way too much time figuring why initramfs wasn't mounting the root dataset.
My root dataset mountpoint is set to legacy. The hook was assuming the root partition was already mounted on `/new_root` and trying to read `/new_root/etc/fstab` to mount legacy datasets.

This is small fix that enables to mount the root dataset with mountpoint=legacy.