### PR TITLE
zfs-utils: Fix wrong zed files in /usr/var/run

### DIFF
--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -34,7 +34,7 @@ build() {
                 --libdir=/usr/lib --datadir=/usr/share --includedir=/usr/include \\
                 --with-udevdir=/usr/lib/udev --libexecdir=/usr/lib \\
                 --with-config=user --enable-systemd --enable-pyzfs \\
-                --with-zfsexecdir=/usr/lib/zfs
+                --with-zfsexecdir=/usr/lib/zfs --localstatedir=/var
     make
 }
 


### PR DESCRIPTION
Fixes archzfs/archzfs#454

Before:
```
[leonghui@me run]$ ls -ld $PWD/*
-rw-r--r-- 1 root root  4 Jul 20 22:46 /usr/var/run/zed.pid
-rw-r--r-- 1 root root 24 Jul 20 23:35 /usr/var/run/zed.state
```

After:
```
[leonghui@me /]$ ls -ld $PWD/* /var/run | grep zed
-rw-r--r--  1 root root        7 Jul 20 23:56 /var/run/zed.pid
-rw-r--r--  1 root root       24 Jul 20 23:49 /var/run/zed.state
```