### PR TITLE
Bump utils pkgrel for openssl 3.0 rebuild

### DIFF
--- a/src/kernels/_utils.sh
+++ b/src/kernels/_utils.sh
@@ -3,10 +3,10 @@ mode_name="utils"
 mode_desc="Select and use the utils packages"
 
 # version
-pkgrel="1"
+pkgrel="2"
 
 # Version for GIT packages
-pkgrel_git="1"
+pkgrel_git="2"
 zfs_git_commit=""
 zfs_git_url="https://github.com/zfsonlinux/zfs.git"
 


### PR DESCRIPTION
zfs utility binaries link against libcrypto.so.1.1 in the existing package. Bump the pkgrel to force a rebuild against libcrypto.so.3

Fixes: https://github.com/archzfs/archzfs/issues/464
Signed-off-by: Joe Groocock <me@frebib.net>