### PR TITLE
Bump ZFS to v2.2.0

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,11 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.1.13"
+openzfs_version="2.2.0"
 openzfs_rc_version="2.1.0-rc8"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="06b24cbb3cbc1554e2edf2fcd71d1f8bec4febf4412aeac17070877c44302abd"
+zfs_src_hash="42035fd059faa25a09cd511b24a57b8ad1285cb69127f2a0043b98562c5ec690"
 zfs_rc_src_hash="8627702ac841d38d5211001c76937e4097719c268b110e8836c0da195618fad2"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"


### PR DESCRIPTION
Did minimal testing by bumping version & hash and running `sudo ./build.sh utils all update make -u -U` in a VM.

FWIW, I thought `./build.sh -U` would download the new versions & bump the src_hash variables but that doesn't seem to be the case.

https://github.com/openzfs/zfs/releases/tag/zfs-2.2.0