### PR TITLE
Update to zfs v2.2.2

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,11 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.2.1"
+openzfs_version="2.2.2"
 openzfs_rc_version="2.1.0-rc8"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="4ff2de43d39710283ae8ff1744aa96e6cdc83c8efe86a715294d4f6bc34a8e8e"
+zfs_src_hash="76bc0547d9ba31d4b0142e417aaaf9f969072c3cb3c1a5b10c8738f39ed12fc9"
 zfs_rc_src_hash="8627702ac841d38d5211001c76937e4097719c268b110e8836c0da195618fad2"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"


### PR DESCRIPTION
This release includes a data corruption bug fix, see https://github.com/openzfs/zfs/issues/15526, https://github.com/openzfs/zfs/pull/15571 and a [developer's summary](https://gist.github.com/rincebrain/e23b4a39aba3fadc04db18574d30dc73)