### PR TITLE
Fix package build issue caused by kmod-33

### DIFF
--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -21,6 +21,11 @@ sha256sums=("${zfs_src_hash}")
 license=("CDDL")
 depends=("kmod" "${zfs_utils_pkgname}" ${linux_depends})
 
+prepare() {
+    cd "${zfs_workdir}"
+    sed -ri 's|(KERNELRELEASE=@LINUX_VERSION@)|\1 DEPMOD=/doesnt/exist|' module/Makefile.in
+}
+
 build() {
     cd "${zfs_workdir}"
     ./autogen.sh

--- a/src/zfs/PKGBUILD.sh
+++ b/src/zfs/PKGBUILD.sh
@@ -46,7 +46,9 @@ package_${zfs_pkgname}() {
     ${zfs_replaces}
 
     cd "${zfs_workdir}"
+    mkdir -p "\${pkgdir}"/usr/share/zfs
     make DESTDIR="\${pkgdir}" INSTALL_MOD_PATH=\${pkgdir}/usr INSTALL_MOD_STRIP=1 install
+    rm -r "\${pkgdir}"/usr/share/zfs
 
     # Remove src dir
     rm -r "\${pkgdir}"/usr/src
@@ -58,7 +60,9 @@ package_${zfs_pkgname}-headers() {
     conflicts=("zfs-headers" "zfs-dkms" "zfs-dkms-git" "zfs-dkms-rc" "spl-dkms" "spl-dkms-git" "spl-headers")
 
     cd "${zfs_workdir}"
+    mkdir -p "\${pkgdir}"/usr/share/zfs
     make DESTDIR="\${pkgdir}" install
+    rm -r "\${pkgdir}"/usr/share/zfs
     rm -r "\${pkgdir}/lib"
 
     # Remove reference to \${srcdir}


### PR DESCRIPTION
This fixes build error which is blocking #542 - the build error is unrelated to zfs 2.2.5 but instead it's a timing accident with kmod-33 release, as explained in the commit. I am not entirely sure that disabling `DEPMOD` is the right way to approach this, but that's the suggested solution in https://bbs.archlinux.org/viewtopic.php?pid=2190572#p2190572 and also what I tested.

The error looks like this
```
  DEPMOD  /build/zfs-linux-lts/pkg/zfs-linux-lts/usr/lib/modules/6.6.46-1-lts
depmod: ERROR: could not open directory /build/zfs-linux-lts/pkg/zfs-linux-lts/usr/usr/lib/modules/6.6.46-1-lts: No such file or directory
depmod: FATAL: could not search modules: No such file or directory
```

The commit which "broke" kmod for us is here

https://gitlab.archlinux.org/archlinux/packaging/packages/kmod/-/commit/0efd732cb78bc0b7851a8367f4dc8e6933f5b99d

This change was only released on 15th Aug in kmod-33 (almost half year after this change).

In another commit, this PR also fixes an unrelated innocuous/dummy error, which looks like this:
```
/bin/sh: line 1: /build/zfs-linux-lts/pkg/zfs-linux-lts-headers/usr/share/zfs/common.sh: No such file or directory
make[3]: [Makefile:13923: scripts-install-data-hook] Error 1 (ignored)
```
