### PR TITLE
Fix stable breaking other kernels

### DIFF
--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -24,6 +24,7 @@ build() {
     sudo bash build.sh -d "$1" make
 }
 
+set +e 
 build utils
 
 build std
@@ -31,6 +32,7 @@ build lts
 build hardened
 build zen
 build dkms
+set -e
 
 # Not implemented, yet, as documented in archzfs-ci
 # sudo bash test.sh ...

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -39,6 +39,17 @@ set -e
 
 rm -rf /src/repo
 mkdir -p /src/repo
+
+# Download the existing packages from experimental so a failure of a kernel build doesn't result in the previously built package going missing.
+current_dir=$(pwd)
+cd /src/repo
+url="https://api.github.com/repos/archzfs/archzfs/releases/latest"
+json_response=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Ap-Version: 2022-11-28" "${url}")
+for x in $(echo "${json_response}" | grep "browser_download_url" | cut -d\" -f4); do
+    wget "${x}"
+done
+cd "${current_dir}"
+
 cp -v /scratch/.buildroot/root/repo/*.pkg.tar* /src/repo/
 
 cd /src/repo


### PR DESCRIPTION
Stopped errors in build from exiting script.
Download last release repo to use as base for building new repo so we don't lose packages.

Problems:
Builds fail silently but this is a quick fix to get builds working again. https://github.com/archzfs/archzfs/issues/560