### PR TITLE
Update to zfs version 2.2.7

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,11 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.2.6"
+openzfs_version="2.2.7"
 openzfs_rc_version="2.3.0-rc1"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="c92e02103ac5dd77bf01d7209eabdca55c7b3356aa747bb2357ec4222652a2a7"
+zfs_src_hash="b2b8e3bfabf2a6407a0132243726cb6762547a5bd095b1b1f37eaf2a9d8f7672"
 zfs_rc_src_hash="a74b54788640629b426bd3ab3f2484e62c4620e899c92096bc8ef5fed1360a0a"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"


### PR DESCRIPTION
# Supported Platforms

* Linux: compatible with 4.18 - 6.12 kernels