### PR TITLE
Handle individual failed kernel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  RELEASE_NAME: experimental
+
 jobs:
   release:
     name: Release
@@ -33,12 +36,12 @@ jobs:
         env:
           GPG_KEY_DATA: "${{ secrets.GPG_KEY_DATA }}"
           GPG_KEY_ID: "${{ vars.GPG_KEY_ID }}"
-        run: docker run -e GPG_KEY_DATA -e GPG_KEY_ID --privileged --rm -v "$(pwd):/src" archzfs-builder
+        run: docker run -e GPG_KEY_DATA -e GPG_KEY_ID -e RELEASE_NAME --privileged --rm -v "$(pwd):/src" archzfs-builder
       - name: Release mainline
         uses: ncipollo/release-action@v1.14.0
         with:
-          name: experimental
-          tag: experimental
+          name: ${{ env.RELEASE_NAME }}
+          tag: ${{ env.RELEASE_NAME }}
           commit: ${{ github.sha }}
           artifacts: ./repo/*
           allowUpdates: true
@@ -48,5 +51,5 @@ jobs:
           removeArtifacts: true
       - uses: rickstaa/action-create-tag@v1.7.2
         with:
-          tag: experimental
+          tag: ${{ env.RELEASE_NAME }}
           force_push_tag: true

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -75,11 +75,9 @@ failover() {
 build utils
 build dkms
 
-sudo mkdir -p /scratch/.buildroot/root/repo
-
 # These are kernel dependant, so they might fail
-build std || failover zfs-linux
 build lts || failover zfs-linux-lts
+build std || failover zfs-linux
 build hardened || failover zfs-linux-hardened
 build zen || failover zfs-linux-zen
 

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -61,9 +61,11 @@ failover() {
         # If BASE is us, that means  we should have built this package
         # so copy it from releases
         if [[ "${pkgbase}" == "${failed_pkg}" ]]; then
+            set -x
             tmp_file="$(mktemp)"
             curl -o "${tmp_file}" -L "${FAILOVER_BASE_URL}/${pkgfile}"
             sudo mv "${tmp_file}" "/scratch/.buildroot/root/repo/${pkgfile}"
+            set +x
         fi
     done
     set -x

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -24,13 +24,19 @@ build() {
     sudo bash build.sh -d "$1" make
 }
 
-build utils
+failover() {
 
-build std
-build lts
-build hardened
-build zen
+}
+
+# These packages must always build
+build utils
 build dkms
+
+# These are kernel dependant, so they might fail
+build std || failover std
+build lts || failover lts
+build hardened || failover hardened
+build zen || failover zen
 
 # Not implemented, yet, as documented in archzfs-ci
 # sudo bash test.sh ...

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -71,11 +71,11 @@ failover() {
     set -x
 }
 
-sudo mkdir -p /scratch/.buildroot/root/repo
-
 # These packages must always build
 build utils
 build dkms
+
+sudo mkdir -p /scratch/.buildroot/root/repo
 
 # These are kernel dependant, so they might fail
 build std || failover zfs-linux

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -12,31 +12,74 @@ fi
 # Only set -x here so we can't accidently print the GPG key up there
 set -x
 
+FAILOVER_REPO_DIR=""
+FAILOVER_BASE_URL=""
+if [ ! -z "${RELEASE_TYPE}" ]; then
+    FAILOVER_REPO_DIR="$(mktemp -d)"
+    cd "${FAILOVER_REPO_DIR}"
+    FAILOVER_BASE_URL="https://github.com/archzfs/archzfs/releases/download/${RELEASE_TYPE}"
+    curl -sL "${FAILOVER_BASE_URL}/archzfs.db.tar.xz" | tar xvJ
+fi
+
 sudo chown -R buildbot:buildbot /src
 cd /src
 
 sed -i "/^THREADS=/s/9/$(nproc)/" ~/.config/clean-chroot-manager.conf
 sudo ccm64 d || true
 
-sudo bash build.sh -d -u all update
+sudo bash build.sh -s -d -u all update
 
 build() {
-    sudo bash build.sh -d "$1" make
+    sudo bash build.sh -s -d "$1" make
 }
 
 failover() {
+    if [ -z "${FAILOVER_REPO_DIR}" ]; then
+        echo "No failover repo available, failing because of: $1"
+        exit 1
+    fi
 
+    failed_pkg="$1"
+
+    set +x # This gets way to verbose
+    for desc in "${FAILOVER_REPO_DIR}"/*/desc; do
+
+        # Iterate lines
+        pkgbase=""
+        pkgfile=""
+        while read -r line; do
+            case "$line" in
+                %FILENAME%)
+                    read -r pkgfile
+                    ;;
+                %BASE%)
+                    read -r pkgbase
+                    ;;
+            esac
+        done < "$desc"
+
+        # If BASE is us, that means  we should have built this package
+        # so copy it from releases
+        if [[ "${pkgbase}" == "${failed_pkg}" ]]; then
+            tmp_file="$(mktemp)"
+            curl -o "${tmp_file}" -L "${FAILOVER_BASE_URL}/${pkgfile}"
+            sudo mv "${tmp_file}" "/scratch/.buildroot/root/repo/${pkgfile}"
+        fi
+    done
+    set -x
 }
+
+sudo mkdir -p /scratch/.buildroot/root/repo
 
 # These packages must always build
 build utils
 build dkms
 
 # These are kernel dependant, so they might fail
-build std || failover std
-build lts || failover lts
-build hardened || failover hardened
-build zen || failover zen
+build std || failover zfs-linux
+build lts || failover zfs-linux-lts
+build hardened || failover zfs-linux-hardened
+build zen || failover zfs-linux-zen
 
 # Not implemented, yet, as documented in archzfs-ci
 # sudo bash test.sh ...


### PR DESCRIPTION
This is my idea for a (fairly) simple solution for the "one or more of the kernels fails to build" issue.

It grabs the `.db` file, and then can use that to find out which packages are actually affected by a failed build and downloads exactly those when needed, thus avoiding the "doubling packages" issue.

`dkms` and `util` are not allowed to fail, as they don't depend on a kernel version.


Further, it also sets the `-s` flag (this is done in the same PR as otherwise I'd have to make `failover` able to handle those packages as well. And I do not think we should offer ZFS git packages (and from the discussions, it seems most agree), especially not on anything we eventually want to be a "stable" repo.