### PR TITLE
Removed the python-future package from the Dockerfile

### DIFF
--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -1,7 +1,8 @@
 FROM archlinux:base-devel
 
 # The following is from https://github.com/archzfs/archzfs-ci/blob/master/worker/Dockerfile
-RUN pacman -Syu --noconfirm --needed python-pipx python-twisted python-future git wget systemd-sysvcompat openresolv vi
+#RUN pacman -Syu --noconfirm --needed python-pipx python-twisted python-future git wget systemd-sysvcompat openresolv vi
+RUN pacman -Syu --noconfirm --needed python-pipx python-twisted git wget systemd-sysvcompat openresolv vi
 
 # add buildbot user and give passwordless sudo access (needed for archzfs build scripts)
 RUN groupadd -r buildbot && \

--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -1,7 +1,6 @@
 FROM archlinux:base-devel
 
-# The following is from https://github.com/archzfs/archzfs-ci/blob/master/worker/Dockerfile
-#RUN pacman -Syu --noconfirm --needed python-pipx python-twisted python-future git wget systemd-sysvcompat openresolv vi
+# The following is adapted from https://github.com/archzfs/archzfs-ci/blob/master/worker/Dockerfile
 RUN pacman -Syu --noconfirm --needed python-pipx python-twisted git wget systemd-sysvcompat openresolv vi
 
 # add buildbot user and give passwordless sudo access (needed for archzfs build scripts)


### PR DESCRIPTION
The python-future package was removed from the extra repository after upgrading to Python version 3.13.
Resolves #567 