### PR TITLE
container build: use the expected env variable name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ name: Build
 permissions:
   contents: read
 
+env:
+  RELEASE_NAME: experimental
+
 jobs:
   build:
     name: Build
@@ -22,4 +25,4 @@ jobs:
       - name: Build builder container
         run: docker build -t archzfs-builder build-container
       - name: Run builder container
-        run: docker run --privileged --rm -v "$(pwd):/src" archzfs-builder
+        run: docker run -e RELEASE_NAME --privileged --rm -v "$(pwd):/src" archzfs-builder

--- a/build-container/entrypoint.sh
+++ b/build-container/entrypoint.sh
@@ -14,10 +14,10 @@ set -x
 
 FAILOVER_REPO_DIR=""
 FAILOVER_BASE_URL=""
-if [ ! -z "${RELEASE_TYPE}" ]; then
+if [ ! -z "${RELEASE_NAME}" ]; then
     FAILOVER_REPO_DIR="$(mktemp -d)"
     cd "${FAILOVER_REPO_DIR}"
-    FAILOVER_BASE_URL="https://github.com/archzfs/archzfs/releases/download/${RELEASE_TYPE}"
+    FAILOVER_BASE_URL="https://github.com/archzfs/archzfs/releases/download/${RELEASE_NAME}"
     curl -sL "${FAILOVER_BASE_URL}/archzfs.db.tar.xz" | tar xvJ
 fi
 


### PR DESCRIPTION
It seems that in #566 there was a discrepancy between the environment variable name in the action file (`RELEASE_NAME`) and the container entrypoint script (`RELEASE_TYPE`), which causes the release action to fail when failover is triggered. Hopefully, I'm not missing something here.