### PR TITLE
add missing ./configure parameters to dkms

### DIFF
--- a/src/kernels/dkms.sh
+++ b/src/kernels/dkms.sh
@@ -3,7 +3,7 @@ mode_name="dkms"
 mode_desc="Select and use the dkms packages"
 
 # version
-pkgrel="1"
+pkgrel="2"
 
 # Version for GIT packages
 pkgrel_git="1"

--- a/src/zfs-dkms/PKGBUILD.sh
+++ b/src/zfs-dkms/PKGBUILD.sh
@@ -10,8 +10,10 @@ pkgrel=${zfs_pkgrel}
 makedepends=(${zfs_makedepends})
 arch=("x86_64")
 url="https://openzfs.org/"
-source=("${zfs_src_target}")
-sha256sums=("${zfs_src_hash}")
+source=("${zfs_src_target}"
+    "dkms-configure.patch")
+sha256sums=("${zfs_src_hash}"
+    "cdb0121720197fe4c00f2725ea5a85de7be0f58806234a6c998de2e26b198334")
 license=("CDDL")
 depends=("${zfs_utils_pkgname}" "lsb-release" "dkms")
 provides=("zfs" "zfs-headers" "spl" "spl-headers")
@@ -27,6 +29,8 @@ build() {
 package() {
     dkmsdir="\${pkgdir}/usr/src/zfs-${zfs_mod_ver}"
     install -d "\${dkmsdir}"
+    cd ${zfs_workdir}
+    patch -Np1 -i ../dkms-configure.patch
     cp -a ${zfs_workdir}/. \${dkmsdir}
 
     cd "\${dkmsdir}"

--- a/src/zfs-dkms/dkms-configure.patch
+++ b/src/zfs-dkms/dkms-configure.patch
@@ -1,0 +1,17 @@
+diff -ura a/scripts/dkms.mkconf b/scripts/dkms.mkconf
+--- a/scripts/dkms.mkconf	2025-03-03 19:41:03.321389279 +0100
++++ b/scripts/dkms.mkconf	2025-03-03 19:58:45.609878706 +0100
+@@ -29,6 +29,13 @@
+   --disable-dependency-tracking
+   --prefix=/usr
+   --with-config=kernel
++  --sysconfdir=/etc
++  --sbindir=/usr/bin
++  --libdir=/usr/lib
++  --datadir=/usr/share
++  --includedir=/usr/include
++  --with-udevdir=/usr/lib/udev
++  --libexecdir=/usr/lib
+   --with-linux=\$(
+     if [ -e "\${kernel_source_dir/%build/source}" ]
+     then


### PR DESCRIPTION
closes #579 

as noted in 579: minextu once replied to my question about the ./configure paramters: "because that's what arch require" or something like this
so while figure out a way to inject --enable-linux-experimental to enable dkms build for 6.13 I also added the missing parameters from regular kernel PKGBUILDs
also bumping pkgrel version