### PR TITLE
update to zfs 2.3.1

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -2,11 +2,11 @@
 #
 # FIXME: reset all kernel configs set to pkgrel=1 when this changes
 #
-openzfs_version="2.3.0"
+openzfs_version="2.3.1"
 openzfs_rc_version="2.3.0-rc5"
 
 # The OpenZFS source hashes are from github.com/openzfs/zfs/releases
-zfs_src_hash="6e8787eab55f24c6b9c317f3fe9b0da9a665eb34c31df88ff368d9a92e9356a6"
+zfs_src_hash="053233799386920bdc636e22d0e19a8c2c3e642e8bd847ff87e108f8bb1f9006"
 zfs_rc_src_hash="dee425d07b28ede44092d41b7244cc9847110e61862772e9faa51b0180e96f52"
 
 zfs_initcpio_install_hash="d19476c6a599ebe3415680b908412c8f19315246637b3a61e811e2e0961aea78"


### PR DESCRIPTION
ZFS 2.3.1 just got released with official support for Linux 2.3.1
https://github.com/openzfs/zfs/releases/tag/zfs-2.3.1