### PR TITLE
actions: don't set commit for release test from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,15 @@ jobs:
         run: docker build -t archzfs-builder build-container
       - name: Run builder container
         run: docker run -e FAILOVER_RELEASE_NAME --privileged --rm -v "$(pwd):/src" archzfs-builder
+      - name: Conditionally set the commit hash for the release action
+        if: github.event.pull_request.head.repo.fork != true
+        run: echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
       - name: Release testing
         uses: ncipollo/release-action@v1.16.0
         with:
           name: ${{ env.RELEASE_NAME }}
           tag: ${{ env.RELEASE_NAME }}
-          commit: ${{ github.sha }}
+          commit: ${{ env.COMMIT_SHA }}
           artifacts: ./repo/*
           allowUpdates: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
This would fix #586 if the culprit is https://github.com/ncipollo/release-action/issues/208#issuecomment-1928581301
> I've noticed that I run into this issue in a forked repo only when I define a `commit` value.
> 
> Creating a release without a commit and the release and tags are created fine, with the commit and it fails.