### PR TITLE
set SUDO_USER explicitly for ccm, fixes #595

### DIFF
--- a/build-container/Dockerfile
+++ b/build-container/Dockerfile
@@ -26,6 +26,8 @@ RUN mkdir -p /tmp/ccm-install            && \
     rm -rfv /tmp/ccm-install
 
 USER root
+# https://github.com/archzfs/archzfs/issues/595
+ENV SUDO_USER=buildbot
 COPY ccm.conf /home/buildbot/.config/clean-chroot-manager.conf
 RUN ccm p && \
     chown -R buildbot:buildbot /home/buildbot && \


### PR DESCRIPTION
[clean-chroot-manager](https://github.com/graysky2/clean-chroot-manager) breaks with version 2.240. It did already break with 2.239, but that was simply because the `ccm64` name had been dropped. This one was more complex, but ultimately it turned out to be a problem on our side.

The problem occurs [here](https://github.com/archzfs/archzfs/blob/98957737458b37c26fcb4f21f519af48edd35a04/build-container/Dockerfile#L30). Debugging shows that the actual error happens in CCM's code [here](https://github.com/graysky2/clean-chroot-manager/blob/93fe17673e9896c451e4c3bd15e70c1e7bd7ba78/common/clean-chroot-manager.in#L53) because it tries to run `getent passwd "$USER"`, but `$USER` is empty so the command is `getent passwd ""`, which inevitably fails.

Why has this worked until now?

It hasn't. The error however had been previously masked. The following two commits helped to reveal it:
- https://github.com/graysky2/clean-chroot-manager/commit/3fc89e11195581eb86b87e4d833d273051a09867
- https://github.com/graysky2/clean-chroot-manager/commit/9b219556a28ba9210517b3d30d64f26b16cb1afa

Before these commits, `getent` was piped into `cut` and, crucially, there was no `set -o pipefail` command in the script. Thus, even if `getent` failed, `cut` was happy enough to exit cleanly.

The real source of the problem is [here](https://github.com/graysky2/clean-chroot-manager/blob/93fe17673e9896c451e4c3bd15e70c1e7bd7ba78/common/clean-chroot-manager.in#L42): CCM apparently expects to always be run by sudo, but in the Dockerfile we were running it under the root user. Without `$SUDO_USER` we ultimately get to `getent` being run with empty parameter.