### PR TITLE
Split ZFS tests and declare zfs-utils dependencies

### DIFF
--- a/ci/releases/body-experimental.md
+++ b/ci/releases/body-experimental.md
@@ -1,4 +1,4 @@
-This is the current official repository of the ArchZFS project. It is built the same way and provides the same set of packages as the now stale `archzfs.com` repository. Except for the different PGP signing key, it can be used as a direct replacement for the old repo.
+This is the current official repository of the ArchZFS project. It replaces the now stale `archzfs.com` repository.
 
 **Important:** While testing the repo is encouraged, we still advise you to be cautious and start with non-critical systems.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,10 @@ DKMS, and the standard, LTS, hardened, and zen Arch kernels. Git, RC, archiso,
 and VFIO package paths remain in the source tree but are not part of the normal
 production build.
 
+The generated `zfs-utils` repository contains one split package base. It emits
+the core `zfs-utils` child and the optional `zfs-tests` child; `zfs-tests` is not
+a separate generated source repository.
+
 ## Production Build
 
 `.github/workflows/release.yml` runs on relevant pushes to `master` and on a
@@ -38,7 +42,8 @@ The container performs the following sequence:
 2. Download and verify the signed repository database from the mutable
    `failover` release.
 3. Recreate the clean build chroot and generate stable PKGBUILDs.
-4. Build `zfs-utils` and `zfs-dkms`; either failure aborts the release.
+4. Build the `zfs-utils` package base and `zfs-dkms`; either failure aborts the
+   release. The utility package base emits both `zfs-utils` and `zfs-tests`.
 5. Build modules for LTS, standard, hardened, and zen kernels.
 6. When an individual kernel build fails, reuse matching packages from
    `failover` only after verifying their detached signatures.

--- a/src/kernels/_utils.sh
+++ b/src/kernels/_utils.sh
@@ -3,7 +3,7 @@ mode_name="utils"
 mode_desc="Select and use the utils packages"
 
 # version
-pkgrel="1"
+pkgrel="2"
 
 # Version for GIT packages
 pkgrel_git="1"
@@ -28,6 +28,8 @@ update_utils_pkgbuilds() {
     zfs_pkgver=${openzfs_version}
     zfs_pkgrel=${pkgrel}
     zfs_utils_pkgname="zfs-utils"
+    zfs_tests_pkgname="zfs-tests"
+    zfs_tests_relations='conflicts=("zfs-tests-git")'
     # Paths are relative to build.sh
     zfs_utils_pkgbuild_path="packages/${kernel_name}/${zfs_utils_pkgname}"
     zfs_src_target="https://github.com/openzfs/zfs/releases/download/zfs-\${pkgver}/zfs-\${pkgver}.tar.gz"
@@ -54,6 +56,9 @@ update_utils_git_pkgbuilds() {
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgrel=${pkgrel_git}
     zfs_utils_pkgname="zfs-utils-git"
+    zfs_tests_pkgname="zfs-tests-git"
+    zfs_tests_relations='provides=("zfs-tests")
+    conflicts=("zfs-tests")'
     zfs_utils_pkgbuild_path="packages/${kernel_name}/${zfs_utils_pkgname}"
     zfs_src_hash="SKIP"
     zfs_makedepends="\"git\""

--- a/src/kernels/_utils.sh
+++ b/src/kernels/_utils.sh
@@ -28,6 +28,7 @@ update_utils_pkgbuilds() {
     zfs_pkgver=${openzfs_version}
     zfs_pkgrel=${pkgrel}
     zfs_utils_pkgname="zfs-utils"
+    zfs_utils_conflicts='conflicts=("spl-utils")'
     zfs_tests_pkgname="zfs-tests"
     zfs_tests_relations='conflicts=("zfs-tests-git")'
     # Paths are relative to build.sh
@@ -56,6 +57,7 @@ update_utils_git_pkgbuilds() {
     zfs_pkgver="" # Set later by call to git_calc_pkgver
     zfs_pkgrel=${pkgrel_git}
     zfs_utils_pkgname="zfs-utils-git"
+    zfs_utils_conflicts='conflicts=("zfs-utils" "spl-utils")'
     zfs_tests_pkgname="zfs-tests-git"
     zfs_tests_relations='provides=("zfs-tests")
     conflicts=("zfs-tests")'

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -74,7 +74,7 @@ package_${zfs_utils_pkgname}() {
     groups=("${archzfs_package_group}")
     provides=("zfs-utils" "spl-utils")
     install=zfs-utils.install
-    conflicts=("zfs-utils" "spl-utils")
+    ${zfs_utils_conflicts}
     ${zfs_utils_replaces}
     backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf')
 

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -2,13 +2,12 @@
 
 cat << EOF > ${zfs_utils_pkgbuild_path}/PKGBUILD
 ${header}
-pkgname="${zfs_utils_pkgname}"
+pkgbase="${zfs_utils_pkgname}"
+pkgname=("${zfs_utils_pkgname}" "${zfs_tests_pkgname}")
 ${zfs_set_commit}
 pkgver=${zfs_pkgver}
 pkgrel=${zfs_pkgrel}
-pkgdesc="Kernel module support files for the Zettabyte File System."
 makedepends=("python" "python-setuptools" "python-cffi" "libaio" ${zfs_makedepends})
-optdepends=("python: pyzfs and extra utilities", "python-cffi: pyzfs")
 arch=("x86_64")
 url="http://openzfs.org/"
 source=("${zfs_src_target}"
@@ -20,12 +19,6 @@ sha256sums=("${zfs_src_hash}"
             "${zfs_initcpio_hook_hash}"
             "${zfs_initcpio_zfsencryptssh_install}")
 license=("CDDL")
-groups=("${archzfs_package_group}")
-provides=("zfs-utils" "spl-utils")
-install=zfs-utils.install
-conflicts=("zfs-utils" "spl-utils")
-${zfs_utils_replaces}
-backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf')
 
 build() {
     cd "${zfs_workdir}"
@@ -34,11 +27,57 @@ build() {
                 --libdir=/usr/lib --datadir=/usr/share --includedir=/usr/include \\
                 --with-udevdir=/usr/lib/udev --libexecdir=/usr/lib \\
                 --with-config=user --enable-systemd --enable-pyzfs \\
-                --with-zfsexecdir=/usr/lib/zfs --localstatedir=/var
+                --with-zfsexecdir=/usr/lib/zfs --localstatedir=/var --without-libunwind
     make
 }
 
-package() {
+package_${zfs_utils_pkgname}() {
+    pkgdesc="Kernel module support files for the Zettabyte File System."
+    depends=(
+        "bash"
+        "coreutils"
+        "diffutils"
+        "findutils"
+        "gawk"
+        "glibc"
+        "grep"
+        "inetutils"
+        "kmod"
+        "libgcc"
+        "libtirpc"
+        "openssl"
+        "pam"
+        "sed"
+        "systemd"
+        "systemd-libs"
+        "util-linux"
+        "util-linux-libs"
+        "zlib"
+    )
+    optdepends=(
+        "curl: HTTP(S) key locations and ZED web notifications"
+        "dracut: dracut initramfs integration"
+        "lsscsi: vdev_id SCSI device identification"
+        "mkinitcpio: mkinitcpio initramfs integration"
+        "multipath-tools: vdev_id multipath device identification"
+        "nfs-utils: NFS sharing"
+        "psmisc: zfsencryptssh initcpio hook"
+        "python: pyzfs and Python utilities"
+        "python-cffi: pyzfs"
+        "s-nail: ZED email notifications"
+        "samba: SMB sharing"
+        "sg3_utils: vdev_id SCSI enclosure identification"
+        "smartmontools: SMART health information in zpool status"
+        "sudo: privilege escalation for SMART zpool status columns"
+        "sysstat: I/O statistics in zpool status"
+    )
+    groups=("${archzfs_package_group}")
+    provides=("zfs-utils" "spl-utils")
+    install=zfs-utils.install
+    conflicts=("zfs-utils" "spl-utils")
+    ${zfs_utils_replaces}
+    backup=('etc/zfs/zed.d/zed.rc' 'etc/default/zfs' 'etc/modules-load.d/zfs.conf')
+
     cd "${zfs_workdir}"
     make DESTDIR="\${pkgdir}" install
 
@@ -56,6 +95,75 @@ package() {
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.install "\${pkgdir}"/usr/lib/initcpio/install/zfs
     install -D -m644 "\${srcdir}"/zfs-utils.initcpio.zfsencryptssh.install "\${pkgdir}"/usr/lib/initcpio/install/zfsencryptssh
     install -D -m644 contrib/bash_completion.d/zfs "\${pkgdir}"/usr/share/bash-completion/completions/zfs
+
+    # Remove the test suite packaged by the sibling child
+    rm -r "\${pkgdir}"/usr/share/zfs/zfs-tests
+    rm -r "\${pkgdir}"/usr/share/zfs/test-runner
+    rm -r "\${pkgdir}"/usr/share/zfs/runfiles
+    rm "\${pkgdir}"/usr/share/zfs/*.sh
+}
+
+package_${zfs_tests_pkgname}() {
+    pkgdesc="Test suite for the Zettabyte File System."
+    depends=(
+        "acl"
+        "attr"
+        "bash"
+        "bc"
+        "binutils"
+        "bzip2"
+        "coreutils"
+        "cpio"
+        "device-mapper"
+        "diffutils"
+        "e2fsprogs"
+        "findutils"
+        "fio"
+        "gawk"
+        "glibc"
+        "grep"
+        "gzip"
+        "kmod"
+        "ksh"
+        "libaio"
+        "lsscsi"
+        "mdadm"
+        "openssl"
+        "parted"
+        "procps-ng"
+        "python"
+        "python-cffi"
+        "sed"
+        "shadow"
+        "sudo"
+        "sysstat"
+        "systemd"
+        "tar"
+        "util-linux"
+        "which"
+        "xxhash"
+        "zfs"
+        "${zfs_utils_pkgname}=\${pkgver}-\${pkgrel}"
+    )
+    optdepends=(
+        "cryptsetup: LUKS tests"
+        "jq: JSON-output tests"
+        "nfs-utils: NFS sharing tests"
+        "openssh: remote NFS performance tests"
+        "perf: performance profiling"
+        "rsync: slog replay and directory comparison tests"
+        "samba: SMB sharing tests"
+        "xfsprogs: XFS loopback interoperability test"
+    )
+    ${zfs_tests_relations}
+
+    cd "${zfs_workdir}"
+    make DESTDIR="\${pkgdir}" install
+
+    find "\${pkgdir}" -mindepth 1 -maxdepth 1 ! -name usr -exec rm -rf {} +
+    find "\${pkgdir}/usr" -mindepth 1 -maxdepth 1 ! -name share -exec rm -rf {} +
+    find "\${pkgdir}/usr/share" -mindepth 1 -maxdepth 1 ! -name zfs -exec rm -rf {} +
+    find "\${pkgdir}/usr/share/zfs" -mindepth 1 -maxdepth 1 ! -name zfs-tests ! -name test-runner ! -name runfiles ! -name "*.sh" -exec rm -rf {} +
 }
 EOF
 

--- a/src/zfs-utils/PKGBUILD.sh
+++ b/src/zfs-utils/PKGBUILD.sh
@@ -123,6 +123,7 @@ package_${zfs_tests_pkgname}() {
         "glibc"
         "grep"
         "gzip"
+        "inetutils"
         "kmod"
         "ksh"
         "libaio"


### PR DESCRIPTION
## Summary

- Pin the existing glibc backtrace behavior with `--without-libunwind`.
- Declare direct runtime dependencies and corrected optional dependencies for `zfs-utils`.
- Move the upstream ZFS Test Suite into an optional `zfs-tests` split-package child.
- Bump stable `zfs-utils` to `2.4.4-2`.
- Document the split package base and correct the experimental repository description.

Addresses #655 without automatically closing it. A current-state response is now posted on the issue; public Wiki corrections and a final issue follow-up will follow production-package verification.

## Motivation

The published `zfs-utils 2.4.4-1` package declares no runtime dependencies and bundles approximately 35 MiB of destructive test infrastructure. Its clean build does not contain libunwind, and none of its 92 ELF objects links it, but the recipe leaves that result to configure-time auto-detection.

This change makes the existing libunwind policy deterministic, records the utility's actual runtime requirements, and separates ZTS from ordinary installations.

## Packaging Impact

The `zfs-utils` package base now emits:

- `zfs-utils`, containing operational utilities, libraries, initramfs integration, and compatibility data;
- `zfs-tests`, containing only the upstream `zfs-tests`, `test-runner`, `runfiles`, and top-level test shell scripts;
- the existing shared debug output.

Only `zfs-utils` remains in the `archzfs-linux` group. `zfs-tests` is optional destructive test infrastructure for disposable systems and depends on the exact matching `zfs-utils` generation plus a `zfs` module provider.

The dormant Git generator receives the equivalent `zfs-utils-git` and `zfs-tests-git` structure. No generated package-repository commits or submodule-pointer updates are included.

## Validation

Validation went substantially beyond confirming that the packages build. It covered generated metadata and exact archive contents, fresh Pacman dependency closure, module loading and initramfs contents, bounded scratch-pool I/O, selected safe ZTS execution, and a successful root-on-ZFS boot across isolated Docker and QEMU environments.

- Passed Bash syntax and whitespace checks.
- Generated stable and dormant Git recipes through the actual `build.sh` update paths.
- Verified generated `.SRCINFO`, package lists, child-scoped metadata, relationships, and conflict handling.
- Completed a full clean-chroot build of utilities, DKMS, and all supported kernel package bases.
- Rebuilt the corrected utility package base after adding the directly required `inetutils` test dependency.
- Inspected `.PKGINFO`, `.BUILDINFO`, archive boundaries, shebangs, `find-libdeps`, namcap output, and every ELF dependency.
- Confirmed the new non-debug children exactly partition the old package payload.
- Confirmed core installation does not pull libunwind, libaio, ksh, Python, or Python CFFI.
- Completed clean Pacman dependency transactions for both children.
- Generated and inspected the ArchZFS initramfs with no test or libunwind payload.
- Loaded the modules and completed disposable scratch-pool I/O and a direct-kernel root-on-ZFS boot.
- Passed ZTS discovery, two deliberately safe ZTS cases, and 107 in-memory pyzfs tests.

The final metadata-only correction was rebuilt and retested through Pacman. Its runtime, test, and debug payloads are byte-identical to the generation used for QEMU and boot validation.

## Limits and Residual Risks

Full or destructive ZTS, physical hardware testing, and the legacy `testing/test.sh` harness were not run.

PR CI passed. Inspection of the unsigned shared `testing` release confirmed all expected package outputs and relationships, clean Pacman installability, and byte-for-byte agreement between its utility-base payloads and the locally validated artifacts.

Installing `zfs-tests` may currently pull libunwind transitively through Arch's `fio` dependency closure. `zfs-utils` itself neither declares nor links it.

Namcap still reports the pre-existing non-SPDX `CDDL` license identifier, and runtime version output retains the pre-existing embedded `2.4.4-1` release suffix. These are follow-up items rather than changes introduced here.

## Documentation and Coordination

Repository architecture and release-body documentation are updated. The README, organization profile, and current Wiki documentation were reviewed; public Wiki updates are prepared separately for publication after the package release.

The current #627/#632/#633 stack has no conflicting package-source change. The documentation hunks merge cleanly with #648 as currently posted. Package-level work in #658 should continue after this split lands, as already noted in that review.
