### PR TITLE
Make pull request builds fork-safe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,25 +10,26 @@ on:
 name: Test
 
 concurrency:
-  group: test
+  group: test-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 env:
-  RELEASE_NAME: testing
   FAILOVER_RELEASE_NAME: failover
 
 jobs:
   test:
-    name: Test release
+    name: Build packages
     runs-on: ubuntu-latest
 
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Build builder container
         run: docker build -t archzfs-builder build-container
@@ -36,22 +37,11 @@ jobs:
       - name: Run builder container
         run: docker run -e FAILOVER_RELEASE_NAME --privileged --rm -v "$(pwd):/src" archzfs-builder
 
-      - name: Release testing
-        uses: ncipollo/release-action@v1.21.0
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.RELEASE_NAME }}
-          tag: ${{ env.RELEASE_NAME }}
-          commit: ${{ github.sha }}
-          artifacts: ./repo/*
-          allowUpdates: true
-          artifactErrorsFailBuild: true
-          omitBody: true
-          omitBodyDuringUpdate: true
-          removeArtifacts: true
-          prerelease: true
-
-      - name: Tag the testing release
-        uses: rickstaa/action-create-tag@v1.7.2
-        with:
-          tag: ${{ env.RELEASE_NAME }}
-          force_push_tag: true
+          name: archzfs-packages-pr-${{ github.event.pull_request.number }}-${{ github.run_attempt }}
+          path: ./repo/*
+          if-no-files-found: error
+          retention-days: 3
+          compression-level: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
   test:
     name: Build packages
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,12 @@
 - For mutable fixed-name releases, do not treat the release tag commit as
   immutable provenance; see **Operational Safety**. Identify signed assets by
   filename, package version, digest, and verified signature. Tie unsigned
-  `testing` assets to their source commit and workflow run as well as their
-  filename, version, and digest. Record whether each was built by that run or
-  reused from signed `failover`. For reused assets, record the verified failover
-  identity; they do not validate candidate package contents. Unsigned assets do
-  not validate production signing or published production contents.
+  pull-request workflow artifacts to their source and merge commits and workflow
+  run as well as their artifact name, filename, version, and digest. Record
+  whether each package was built by that run or reused from signed `failover`.
+  For reused assets, record the verified failover identity; they do not validate
+  candidate package contents. Unsigned assets do not validate production signing
+  or published production contents.
 - Record package identities and versions, artifact names and URLs, signature
   verification, digests, commits or tags, and discrepancies in durable task
   evidence and in any applicable pull request or review. Preserve conflicting
@@ -135,8 +136,8 @@
 - Although listed in `build.sh --help`, `test` and `update-test` are parsed but
   have no execution path. Do not report them as validation.
 - The Actions workflow named `Test` performs an unsigned package build and
-  updates the shared mutable `testing` release. It does not run the legacy
-  QEMU tests or an OpenZFS runtime/data-integrity suite.
+  retains its output as a short-lived workflow artifact. It does not run the
+  legacy QEMU tests or an OpenZFS runtime/data-integrity suite.
 - Long package-build checks may run automatically for changes that cannot affect
   their workflow, inputs, or outputs. After inspecting the changed paths and
   relevant workflow dependencies, do not wait synchronously merely for such a
@@ -165,8 +166,9 @@
 - Do not force-sync `archzfs-testing` until active work is preserved and
   mutating workflows are disabled. `gh repo sync --force` hard-resets its target
   branch; follow `docs/staging.md` and verify the destination repository.
-- Releases and tags named `testing`, `experimental`, and `failover` are mutable
-  and may be force-moved. Do not use their tag commits as immutable provenance.
+- Releases and tags named `experimental` and `failover`, and any retained legacy
+  `testing` release and tag, are mutable and may be force-moved. Do not use their
+  tag commits as immutable provenance.
 - Preserve create-then-promote publication for fixed-name release channels. In
   addition to reducing exposure to incomplete uploads, creating a fresh release
   updates the date shown by GitHub; updating assets in place does not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,12 @@
 - Do not run `testing/test.sh` on an unreviewed environment. Guest setup wipes
   the test VM's `/dev/vda`, depends on hard-coded NFS resources, and has
   unfinished acceptance checks.
+- Pull-request workflows execute unreviewed contributor code in a privileged
+  container. Keep them free of repository write permissions, repository or
+  environment secrets, secret-bearing environments, persisted checkout
+  credentials, and authority to publish to organization-owned channels. Do not
+  assume every fork run is approval-gated; repository policy may allow some runs
+  to start automatically.
 - Do not force-sync `archzfs-testing` until active work is preserved and
   mutating workflows are disabled. `gh repo sync --force` hard-resets its target
   branch; follow `docs/staging.md` and verify the destination repository.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,12 +78,14 @@ Creating a new release before renaming it gives users a meaningful publication
 date. Future fixed-name channels need to preserve both properties or replace
 them deliberately; the current sequence reduces risk but is not fully atomic.
 
-The fixed names are channels rather than immutable versions:
+The fixed release names are channels rather than immutable versions:
 
 - `experimental`: current signed public Pacman repository.
 - `failover`: signed prior/current package pool used to keep a repository
   publishable when an individual kernel-module build fails.
-- `testing`: unsigned mutable output of the pull-request workflow.
+
+The former `testing` release may remain as stale historical output. The
+pull-request workflow no longer updates it, and it is not an active channel.
 
 Consumers must verify repository and package signatures rather than treating a
 release tag's Git commit as permanent artifact identity.
@@ -145,11 +147,13 @@ not a supported path merely because it remains in the repository.
 
 ## Validation Boundaries
 
-The workflow named `Test` builds package artifacts in the same privileged
-container and publishes a shared mutable prerelease. It verifies that package
-generation and clean-chroot builds complete, subject to release-token
-permissions. It does not run an automated OpenZFS filesystem, boot, upgrade, or
-data-integrity test suite.
+The workflow named `Test` builds packages in the same privileged container and
+stores the resulting unsigned repository as a short-lived workflow artifact.
+It uses a read-only repository token, so external-fork workflows approved under
+repository policy can receive the same build as pull requests from organization
+branches without publishing or mutating a release. It verifies that package
+generation and clean-chroot builds complete. It does not run an automated
+OpenZFS filesystem, boot, upgrade, or data-integrity test suite.
 
 The older `testing/` harness requires root, KVM/QEMU, Packer, NFS, and hard-coded
 host resources. Its guest setup is destructive and its acceptance checks are

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,11 +149,14 @@ not a supported path merely because it remains in the repository.
 
 The workflow named `Test` builds packages in the same privileged container and
 stores the resulting unsigned repository as a short-lived workflow artifact.
-It uses a read-only repository token, so external-fork workflows approved under
-repository policy can receive the same build as pull requests from organization
-branches without publishing or mutating a release. It verifies that package
-generation and clean-chroot builds complete. It does not run an automated
-OpenZFS filesystem, boot, upgrade, or data-integrity test suite.
+It uses a read-only repository token, so once admitted by repository policy,
+external-fork workflows can receive the same build as pull requests from
+organization branches without publishing or mutating a release. It verifies
+that package generation and clean-chroot builds complete. A successful run may
+still include signed kernel packages reused from `failover` after an individual
+kernel-family build failure; inspect the log and record which packages were
+built or reused before citing build coverage. The workflow does not run an
+automated OpenZFS filesystem, boot, upgrade, or data-integrity test suite.
 
 The older `testing/` harness requires root, KVM/QEMU, Packer, NFS, and hard-coded
 host resources. Its guest setup is destructive and its acceptance checks are
@@ -168,3 +171,10 @@ builder deliberately imports it before enabling command tracing.
 Failover reuse depends on both the signed repository database and detached
 package signatures. Release changes must preserve those checks and the rule
 that utilities and DKMS packages cannot silently fall back after failed builds.
+
+Pull-request workflows execute unreviewed contributor code in a privileged
+container that mounts the checkout. They must not receive repository write
+permission, repository or environment secrets, a secret-bearing environment,
+persisted checkout credentials, or authority to publish to an
+organization-owned channel. Workflow approval is not a trust boundary: whether
+a fork run requires human approval depends on mutable repository policy.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,12 +88,12 @@ edge, and what support and retention users can expect.
 
 **Status: Deployed for package builds; runtime validation remains incomplete**
 
-The pull-request workflow builds package candidates and retains them briefly as
-immutable workflow artifacts tied to their individual runs. It uses no
-repository write permission, so external-fork workflows approved under
-repository policy can receive the same build validation as organization pull
-requests. These unsigned artifacts are not end-user channels and do not
-demonstrate production signing or publication behavior.
+The pull-request workflow builds package candidates and retains them for three
+days as per-run workflow artifacts that cannot be overwritten in place but can
+be deleted. It uses no repository write permission, so once admitted by
+repository policy, external-fork workflows can receive the same build validation
+as organization pull requests. These unsigned artifacts are not end-user
+channels and do not demonstrate production signing or publication behavior.
 
 `archzfs-testing` has a separate purpose: it is the disposable staging fork for
 release-infrastructure changes. Watchers, publication changes, and other CI work

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # ArchZFS Roadmap
 
-Last reviewed: 2026-07-12
+Last reviewed: 2026-09-10
 
 This document records the current maintainer's working direction and open design
 work. It is not a release schedule, and nothing described as staging, proposed,
@@ -86,15 +86,14 @@ edge, and what support and retention users can expect.
 
 ### CI Validation
 
-**Status: Partially deployed**
+**Status: Deployed for package builds; runtime validation remains incomplete**
 
-Package candidates should normally exist only as ephemeral workflow artifacts
-until validation succeeds. A mutable release such as `testing` may be used when
-persistent assets are technically necessary, but it is not an end-user channel
-and developers should rarely need to install from it. The current shared release
-also cannot be updated reliably by fork-originated pull requests because of
-GitHub token permissions tracked in
-[issue #586](https://github.com/archzfs/archzfs/issues/586).
+The pull-request workflow builds package candidates and retains them briefly as
+immutable workflow artifacts tied to their individual runs. It uses no
+repository write permission, so external-fork workflows approved under
+repository policy can receive the same build validation as organization pull
+requests. These unsigned artifacts are not end-user channels and do not
+demonstrate production signing or publication behavior.
 
 `archzfs-testing` has a separate purpose: it is the disposable staging fork for
 release-infrastructure changes. Watchers, publication changes, and other CI work

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -259,9 +259,9 @@ The production PR should state:
 - Failure paths, retries, or destructive cases that were not exercised.
 - Expected release, tag, failover, and generated-artifact impact.
 
-Normal production PR checks still apply. Their inability to mutate a shared
-release from fork-originated code is a known boundary, not a reason to grant
-untrusted code broader credentials.
+Normal production PR checks still apply. They deliberately retain package
+candidates as workflow artifacts rather than mutating a shared release; this
+boundary is not a reason to grant untrusted code broader credentials.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary

- Replace pull-request publication to the shared mutable `testing` release with a three-day, per-run workflow artifact containing the unsigned `repo/` output.
- Reduce the workflow token to `contents: read`, disable persisted checkout credentials, and pin both third-party actions by commit SHA.
- Scope concurrency per pull request, add a 60-minute job timeout, and document the security and validation boundaries.

Closes #586

## Motivation

Fork-originated `pull_request` runs receive a read-only token and no repository secrets. Maintainer approval can permit a run to start, but it does not elevate that token. Existing fork runs completed the package build and then failed only when attempting to mutate the shared `testing` release with HTTP 403.

PR #638 provides the verified cross-repository example: its [workflow run](https://github.com/archzfs/archzfs/actions/runs/25767625539) completed `Run builder container` successfully and failed at `Release testing`. The same head commit was then reopened from an organization branch as #639, where the release-mutating workflow succeeded. PR #628 was itself cross-repository and is not treated as an internal reopen.

Publishing a release is not test coverage. This change preserves the same privileged recipe-generation and clean-chroot package build, but retains each run's output through `actions/upload-artifact` instead of granting contributor-controlled code authority over an organization release. No cancellable step mutates shared release state.

## Security And Validation Boundaries

- The workflow declares only `contents: read` and receives no secret-bearing environment.
- Checkout uses `persist-credentials: false` before the repository is mounted into the privileged builder container.
- `actions/checkout` and `actions/upload-artifact` are pinned by full commit SHA.
- Artifact names include the pull-request number and run attempt, and concurrency is scoped to the pull-request number.
- A green run may contain signed kernel packages reused from the verified `failover` release after an individual kernel-family build failure. The logs must be inspected before claiming that every package was built from the pull request.
- This validates recipe generation and clean-chroot builds only. It is not an OpenZFS runtime, boot, module-load, pool-import, upgrade, or data-integrity test.
- The legacy `testing` release and tag remain untouched pending separate, explicit retirement.

Repository documentation is updated in this branch. Coordinated Wiki commits remain local and should be published only after this change merges.

Static validation passed. A genuine fork-originated artifact upload is intentionally still pending and its run and artifact evidence will be recorded on this pull request.
